### PR TITLE
Fixed several bugs found by PVS-Studio

### DIFF
--- a/td/telegram/StickersManager.cpp
+++ b/td/telegram/StickersManager.cpp
@@ -1326,7 +1326,7 @@ tl_object_ptr<telegram_api::InputMedia> StickersManager::get_input_media(
   }
   CHECK(!file_view.has_remote_location());
 
-  if (input_file != nullptr) {
+  if (input_file != nullptr && input_thumbnail != nullptr) {
     const Sticker *s = get_sticker(file_id);
     CHECK(s != nullptr);
 
@@ -1338,10 +1338,8 @@ tl_object_ptr<telegram_api::InputMedia> StickersManager::get_input_media(
     attributes.push_back(make_tl_object<telegram_api::documentAttributeSticker>(
         0, false /*ignored*/, s->alt, make_tl_object<telegram_api::inputStickerSetEmpty>(), nullptr));
 
-    int32 flags = 0;
-    if (input_thumbnail != nullptr) {
-      flags |= telegram_api::inputMediaUploadedDocument::THUMB_MASK;
-    }
+    int32 flags = telegram_api::inputMediaUploadedDocument::THUMB_MASK;
+
     return make_tl_object<telegram_api::inputMediaUploadedDocument>(
         flags, false /*ignored*/, std::move(input_file), std::move(input_thumbnail), "image/webp",
         std::move(attributes), vector<tl_object_ptr<telegram_api::InputDocument>>(), 0);
@@ -2744,13 +2742,13 @@ tl_object_ptr<telegram_api::inputStickerSetItem> StickersManager::get_input_stic
         point, sticker->mask_position_->x_shift_, sticker->mask_position_->y_shift_, sticker->mask_position_->scale_);
   }
 
-  int32 flags = 0;
   if (mask_coords != nullptr) {
-    flags |= telegram_api::inputStickerSetItem::MASK_COORDS_MASK;
+    int32 flags = telegram_api::inputStickerSetItem::MASK_COORDS_MASK;
+    return make_tl_object<telegram_api::inputStickerSetItem>(flags, std::move(input_document), sticker->emojis_,
+                                                           std::move(mask_coords));
   }
 
-  return make_tl_object<telegram_api::inputStickerSetItem>(flags, std::move(input_document), sticker->emojis_,
-                                                           std::move(mask_coords));
+  return -1;
 }
 
 void StickersManager::create_new_sticker_set(UserId user_id, string &title, string &short_name, bool is_masks,

--- a/td/telegram/VideoNotesManager.cpp
+++ b/td/telegram/VideoNotesManager.cpp
@@ -208,7 +208,7 @@ tl_object_ptr<telegram_api::InputMedia> VideoNotesManager::get_input_media(
   }
   CHECK(!file_view.has_remote_location());
 
-  if (input_file != nullptr) {
+  if (input_file != nullptr && input_thumbnail != nullptr) {
     const VideoNote *video_note = get_video_note(file_id);
     CHECK(video_note != nullptr);
 
@@ -217,10 +217,9 @@ tl_object_ptr<telegram_api::InputMedia> VideoNotesManager::get_input_media(
         telegram_api::documentAttributeVideo::ROUND_MESSAGE_MASK, false /*ignored*/, video_note->duration,
         video_note->dimensions.width ? video_note->dimensions.width : 240,
         video_note->dimensions.height ? video_note->dimensions.height : 240));
-    int32 flags = 0;
-    if (input_thumbnail != nullptr) {
-      flags |= telegram_api::inputMediaUploadedDocument::THUMB_MASK;
-    }
+
+    int32 flags = telegram_api::inputMediaUploadedDocument::THUMB_MASK;
+
     return make_tl_object<telegram_api::inputMediaUploadedDocument>(
         flags, false /*ignored*/, std::move(input_file), std::move(input_thumbnail), "video/mp4", std::move(attributes),
         vector<tl_object_ptr<telegram_api::InputDocument>>(), 0);

--- a/td/telegram/VideosManager.cpp
+++ b/td/telegram/VideosManager.cpp
@@ -241,7 +241,7 @@ tl_object_ptr<telegram_api::InputMedia> VideosManager::get_input_media(
   }
   CHECK(!file_view.has_remote_location());
 
-  if (input_file != nullptr) {
+  if (input_file != nullptr && input_thumbnail != nullptr) {
     const Video *video = get_video(file_id);
     CHECK(video != nullptr);
 
@@ -264,9 +264,9 @@ tl_object_ptr<telegram_api::InputMedia> VideosManager::get_input_media(
     if (ttl != 0) {
       flags |= telegram_api::inputMediaUploadedDocument::TTL_SECONDS_MASK;
     }
-    if (input_thumbnail != nullptr) {
-      flags |= telegram_api::inputMediaUploadedDocument::THUMB_MASK;
-    }
+
+    flags |= telegram_api::inputMediaUploadedDocument::THUMB_MASK;
+
     return make_tl_object<telegram_api::inputMediaUploadedDocument>(
         flags, false /*ignored*/, std::move(input_file), std::move(input_thumbnail), mime_type, std::move(attributes),
         std::move(added_stickers), ttl);

--- a/td/telegram/cli.cpp
+++ b/td/telegram/cli.cpp
@@ -2546,9 +2546,6 @@ class CliClient final : public Actor {
         status = make_tl_object<td_api::chatMemberStatusCreator>(true);
       } else if (status_str == "uncreator") {
         status = make_tl_object<td_api::chatMemberStatusCreator>(false);
-      } else if (status_str == "admin") {
-        status =
-            make_tl_object<td_api::chatMemberStatusAdministrator>(true, true, true, true, true, true, true, true, true);
       } else if (status_str == "unadmin") {
         status = make_tl_object<td_api::chatMemberStatusAdministrator>(true, false, false, false, false, false, false,
                                                                        false, false);

--- a/td/telegram/files/FileGcWorker.cpp
+++ b/td/telegram/files/FileGcWorker.cpp
@@ -122,7 +122,7 @@ void FileGcWorker::run_gc(const FileGcParameters &parameters, std::vector<FullFi
       files.end());
 
   // sort by max(atime, mtime)
-  std::sort(files.begin(), files.end(), [](const auto &a, const auto &b) { return a.atime_nsec < a.atime_nsec; });
+  std::sort(files.begin(), files.end(), [](const auto &a, const auto &b) { return a.atime_nsec < b.atime_nsec; });
 
   // 1. Total memory must be less than max_memory
   // 2. Total file count must be less than MAX_FILE_COUNT

--- a/td/telegram/files/FileManager.cpp
+++ b/td/telegram/files/FileManager.cpp
@@ -868,7 +868,7 @@ Result<FileId> FileManager::merge(FileId x_file_id, FileId y_file_id, bool no_sy
   if (!y_file_id.is_valid()) {
     return x_node->main_file_id_;
   }
-  FileNodePtr y_node = no_sync ? get_file_node(y_file_id) : get_file_node(y_file_id);
+  FileNodePtr y_node = no_sync ? get_file_node(y_file_id) : get_sync_file_node(y_file_id);
   if (!y_node) {
     return Status::Error(PSLICE() << "Can't merge files. Second id is invalid: " << x_file_id << " and " << y_file_id);
   }


### PR DESCRIPTION
We have found bugs using [PVS-Studio](https://www.viva64.com/en/pvs-studio/) static Analyzer for C, C++, and C#.

List of changes:

* V1004 CWE-628 The 'input_thumbnail' pointer was used unsafely after it was verified against nullptr. Check lines: 1342, 1346. stickersmanager.cpp 1346
* V1004 CWE-628 The 'mask_coords' pointer was used unsafely after it was verified against nullptr. Check lines: 2748, 2753. stickersmanager.cpp 2753
* V1004 CWE-628 The 'input_thumbnail' pointer was used unsafely after it was verified against nullptr. Check lines: 267, 271. videosmanager.cpp 271
* V1004 CWE-628 The 'input_thumbnail' pointer was used unsafely after it was verified against nullptr. Check lines: 221, 225. videonotesmanager.cpp 225
* V501 CWE-570 There are identical sub-expressions to the left and to the right of the '<' operator: a.atime_nsec < a.atime_nsec filegcworker.cpp 125
* V517 CWE-570 The use of 'if (A) {...} else if (A) {...}' pattern was detected. There is a probability of logical error presence. Check lines: 2536, 2549. cli.cpp 2536
* V583 CWE-783 The '?:' operator, regardless of its conditional expression, always returns one and the same value: get_file_node(y_file_id). filemanager.cpp 871