### PR TITLE
Make result type safe

### DIFF
--- a/example/java/org/drinkless/tdlib/Client.java
+++ b/example/java/org/drinkless/tdlib/Client.java
@@ -18,14 +18,16 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 public final class Client implements Runnable {
     /**
      * Interface for handler for results of queries to TDLib and incoming updates from TDLib.
+     *
+     * @param <T> The result type
      */
-    public interface ResultHandler {
+    public interface ResultHandler<T extends TdApi.Object> {
         /**
          * Callback called on result of query to TDLib or incoming update from TDLib.
          *
          * @param object Result of query or update of type TdApi.Update about new events.
          */
-        void onResult(TdApi.Object object);
+        void onResult(T object);
     }
 
     /**


### PR DESCRIPTION
I'd like to add a generic type T to `Client.ResultHandler`, which helps to determine the result type and avoid unnecessary switch-case statement. For example, querying the chat history using `TdApi#GetChatHistory(...)` will return a `TdApi.Messages` object.

Previously, we need to do:

```java
private static class MessageHandler implements Client.ResultHandler {
  @Override
  public void onResult(TdApi.Object object) {
    switch (object.getConstructor()) {
      case Messages.CONSTRUCTOR: {
        Messages messages = (Messages) object;
        for (Message msg : messages.messages) {
          ...
        }
        break;
      }
      default:
        System.out.println("This should never happen");
        break;
    }
  }
}
```

Now we can do:

```java
private static class MessageHandler implements Client.ResultHandler<Messages> {
  @Override
  public void onResult(Messages messages) {
    for (Message msg : messages.messages) {
      ...
    }
  }
}
```