### PR TITLE
Fixed ARM UWP Build with Visual Studio 2017

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,3 @@ auto/
 db_backup
 *.pyc
 docs/
-/.vs/td/v15/Browse.VC.opendb
-/.vs/td/v15/Browse.VC.db
-/.vs/slnx.sqlite
-/.vs/ProjectSettings.json

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ auto/
 db_backup
 *.pyc
 docs/
+/.vs/td/v15/Browse.VC.opendb
+/.vs/td/v15/Browse.VC.db
+/.vs/slnx.sqlite
+/.vs/ProjectSettings.json

--- a/example/uwp/build.ps1
+++ b/example/uwp/build.ps1
@@ -9,7 +9,7 @@ $ErrorActionPreference = "Stop"
 $vcpkg_root = Resolve-Path $vcpkg_root
 
 $vcpkg_cmake="${vcpkg_root}\scripts\buildsystems\vcpkg.cmake"
-$arch_list = @( "x86", "x64", "arm" )
+$arch_list = @( "x86", "x64", "ARM" )
 if ($arch) {
   $arch_list = @(, $arch)
 }


### PR DESCRIPTION
With Visual Studio 2017 build tools/IDE, the current build.ps1 script always throws "error MSB8022: Building Desktop applications for the ARM platform is not supported" every time that cmake tries to generate project files for arm architecture.

Build tools seem to not recognize the "arm" architecture or they are trying to build non-UWP projects because of lower case architecture name (with the same tools and SDK, the build configuration only succed when "arm" is written in upper case).