### PR TITLE
Use standard escape sequences

### DIFF
--- a/tdutils/td/utils/logging.h
+++ b/tdutils/td/utils/logging.h
@@ -152,12 +152,12 @@ void set_log_fatal_error_callback(OnFatalErrorCallback callback);
 
 [[noreturn]] void process_fatal_error(CSlice message);
 
-#define TC_RED "\e[1;31m"
-#define TC_BLUE "\e[1;34m"
-#define TC_CYAN "\e[1;36m"
-#define TC_GREEN "\e[1;32m"
-#define TC_YELLOW "\e[1;33m"
-#define TC_EMPTY "\e[0m"
+#define TC_RED "\x1b[1;31m"
+#define TC_BLUE "\x1b[1;34m"
+#define TC_CYAN "\x1b[1;36m"
+#define TC_GREEN "\x1b[1;32m"
+#define TC_YELLOW "\x1b[1;33m"
+#define TC_EMPTY "\x1b[0m"
 
 class TsCerr {
  public:


### PR DESCRIPTION
In tdutils/td/utils/logging.h it had the non-standard \e escape, which causes some warnings when compiling in standard mode (or errors with -Werror) so I replaced it with the standard hex escape sequence.