### PR TITLE
Add a function to get the current log verbosity

### DIFF
--- a/td/telegram/Log.cpp
+++ b/td/telegram/Log.cpp
@@ -46,6 +46,10 @@ void Log::set_verbosity_level(int new_verbosity_level) {
   SET_VERBOSITY_LEVEL(VERBOSITY_NAME(FATAL) + new_verbosity_level);
 }
 
+int Log::get_verbosity_level() {
+  return GET_VERBOSITY_LEVEL();
+}
+
 void Log::set_fatal_error_callback(FatalErrorCallbackPtr callback) {
   if (callback == nullptr) {
     fatal_error_callback = nullptr;

--- a/td/telegram/Log.h
+++ b/td/telegram/Log.h
@@ -59,6 +59,13 @@ class Log {
   static void set_verbosity_level(int new_verbosity_level);
 
   /**
+   * Returns the verbosity level of the internal logging of TDLib.
+   *
+   * \return The verbosity level as set from set_verbosity_level, or the default value (5)
+   */
+  static int get_verbosity_level();
+
+  /**
    * A type of callback function that will be called when a fatal error happens.
    *
    * \param error_message Null-terminated string with a description of a happened fatal error.


### PR DESCRIPTION
I noticed that Log has a function to set log verbosity but not to get the current value, so I've added a function that does that.

The rationale is that I wanted to write a client using tdlib where the logging level is configurable, so I need a way to retrieve it.