### PR TITLE
Added SOVERSION to shared libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -804,3 +804,7 @@ write_basic_package_version_file("TdConfigVersion.cmake"
 install(FILES "TdConfig.cmake" "${CMAKE_CURRENT_BINARY_DIR}/TdConfigVersion.cmake"
   DESTINATION lib/cmake/Td
 )
+
+# Add SOVERSION to shared libraries
+set_property(TARGET tdclient PROPERTY SOVERSION ${TDLib_VERSION})
+set_property(TARGET tdjson PROPERTY SOVERSION ${TDLib_VERSION})


### PR DESCRIPTION
Added SOVERSION to shared libraries.
SOVERSION required for all major GNU/Linux distributions.