### PR TITLE
Fix typo mistake

### DIFF
--- a/tdtl/td/tl/tl_config.cpp
+++ b/tdtl/td/tl/tl_config.cpp
@@ -327,7 +327,7 @@ tl_type *tl_config_parser::read_type() {
 tl_config tl_config_parser::parse_config() {
   schema_version = get_schema_version(try_parse_int());
   if (schema_version < 2) {
-    std::fprintf(stderr, "Unsupported tl-schema verdion %d\n", static_cast<int>(schema_version));
+    std::fprintf(stderr, "Unsupported tl-schema version %d\n", static_cast<int>(schema_version));
     std::abort();
   }
 


### PR DESCRIPTION
In English the right word is "version" instead of "verdion" which has no meaning in the language.
Just replace the word with the correct one