### PR TITLE
Preliminary FreeBSD support

### DIFF
--- a/tdutils/td/utils/port/IPAddress.h
+++ b/tdutils/td/utils/port/IPAddress.h
@@ -18,6 +18,10 @@
 #include <sys/socket.h>
 #endif
 
+#if TD_FREEBSD
+#include <netinet/in.h>
+#endif
+
 namespace td {
 
 Result<string> idn_to_ascii(CSlice host);

--- a/tdutils/td/utils/port/config.h
+++ b/tdutils/td/utils/port/config.h
@@ -25,7 +25,7 @@
 #elif TD_EMSCRIPTEN
   #define TD_POLL_POLL 1
   #define TD_EVENTFD_UNSUPPORTED 1
-#elif TD_DARWIN
+#elif TD_DARWIN || TD_FREEBSD
   #define TD_POLL_KQUEUE 1
   #define TD_EVENTFD_BSD 1
 #elif TD_WINDOWS

--- a/tdutils/td/utils/port/platform.h
+++ b/tdutils/td/utils/port/platform.h
@@ -47,6 +47,8 @@
   #define TD_CYGWIN 1
 #elif defined(__EMSCRIPTEN__)
   #define TD_EMSCRIPTEN 1
+#elif defined(__FreeBSD__)
+  #define TD_FREEBSD 1
 #elif defined(__unix__)  // all unices not caught above
   #warning "Probably unsupported Unix platform. Feel free to try to compile"
   #define TD_CYGWIN 1


### PR DESCRIPTION
- Add `__FreeBSD__` define
- FreeBSD and Darwin use the same poll implementation
- Include a needed header for `sockaddr_in{,6}`

Builds successfully on FreeBSD 13-CURRENT; should have no problem with 12.0-RELEASE, 12-STABLE, 11.2-RELEASE or 11-STABLE.