### PR TITLE
Fix Python-Apple-Support dependency checkout

### DIFF
--- a/example/ios/build-openssl.sh
+++ b/example/ios/build-openssl.sh
@@ -2,7 +2,7 @@
 
 git clone https://github.com/pybee/Python-Apple-support
 cd Python-Apple-support
-git checkout 2.7
+git checkout tags/2.7-b5 -b archs-all
 cd ..
 
 #TODO: change openssl version


### PR DESCRIPTION
- Last Python-Support release dropped support for arm7, armv7s builds so previous release tag must be pined until corresponding archs will be dropped from tdlib.

Signed-off-by: Russel <emkil.russel@gmail.com>