### PR TITLE
Fix for loading asm.js version of tdweb

### DIFF
--- a/example/web/tdweb/src/worker.js
+++ b/example/web/tdweb/src/worker.js
@@ -99,7 +99,7 @@ async function loadTdlibAsmjs(onFS) {
   console.log('got td_asm.js');
   const fromFile = 'td_asmjs.js.mem';
   const toFile = td_asmjs_mem_release;
-  const module = Module({
+  const module = Module.default({
     onRuntimeInitialized: () => {
       console.log('runtime intialized');
     },

--- a/example/web/tdweb/src/worker.js
+++ b/example/web/tdweb/src/worker.js
@@ -144,7 +144,7 @@ async function loadTdlib(mode, onFS) {
     if (mode === 'wasm') {
       log.error('WebAssembly is not supported, trying to use it anyway');
     } else {
-      log.warning('WebAssembly is not supported, trying to use asm.js');
+      log.warn('WebAssembly is not supported, trying to use asm.js');
       mode = 'asmjs';
     }
   }


### PR DESCRIPTION
When attempting to run the asmjs version of tdweb, I ran into a few issues. This PR fixes them:

1. `log.warning` is replaced with the correct call, `log.warn`
1. `Module.default` is used as opposed to `Module`