### PR TITLE
tdutils: Fix build for alpine linux

### DIFF
--- a/tdutils/td/utils/port/detail/ThreadPthread.cpp
+++ b/tdutils/td/utils/port/detail/ThreadPthread.cpp
@@ -14,7 +14,9 @@ char disable_linker_warning_about_empty_file_thread_pthread_cpp TD_UNUSED;
 
 #include <pthread.h>
 #include <sched.h>
+#if TD_FREEBSD || TD_OPENBSD || TD_NETBSD
 #include <sys/sysctl.h>
+#endif
 #include <unistd.h>
 
 namespace td {


### PR DESCRIPTION
* Alpine doesn't use sys/sysctl header for syscalls

* Error log: https://del.dog/ujofeqowol 