### PR TITLE
td/telegram/files/FileEncryptionKey.cpp: remove redundant condition

### DIFF
--- a/td/telegram/files/FileEncryptionKey.cpp
+++ b/td/telegram/files/FileEncryptionKey.cpp
@@ -92,9 +92,6 @@ StringBuilder &operator<<(StringBuilder &string_builder, const FileEncryptionKey
   if (key.is_secret()) {
     return string_builder << "SecretKey{" << key.size() << "}";
   }
-  if (key.is_secret()) {
-    return string_builder << "SecureKey{" << key.size() << "}";
-  }
   return string_builder << "NoKey{}";
 }
 


### PR DESCRIPTION
found by cppcheck

[td/telegram/files/FileEncryptionKey.cpp:92] -> [td/telegram/files/FileEncryptionKey.cpp:95]: (warning) Identical condition 'key.is_secret()', second condition is always false