### PR TITLE
Add missing Windows header (winioctl.h).

### DIFF
--- a/tdutils/td/utils/port/FileFd.cpp
+++ b/tdutils/td/utils/port/FileFd.cpp
@@ -32,6 +32,10 @@
 #include <unistd.h>
 #endif
 
+#if TD_PORT_WINDOWS
+#include <winioctl.h>
+#endif
+
 namespace td {
 
 namespace {


### PR DESCRIPTION
`td-1.6.0/tdutils/td/utils/port/FileFd.cpp(213): error C2065: 'FSCTL_SET_SPARSE': undeclared identifier`

The latest MSVC (VS 2019 16.5) and WinSDK.
MSDN also says that FSCTL_SET_SPARSE is defined in `winioctl.h`.