### PR TITLE
Surround IPv6 addresses by square braquets in HTTP CONNECT requests

### DIFF
--- a/tdnet/td/net/HttpProxy.cpp
+++ b/tdnet/td/net/HttpProxy.cpp
@@ -20,7 +20,13 @@ void HttpProxy::send_connect() {
   CHECK(state_ == State::SendConnect);
   state_ = State::WaitConnectResponse;
 
-  string host = PSTRING() << ip_address_.get_ip_str() << ':' << ip_address_.get_port();
+  string host;
+  if (ip_address_.is_ipv6()) {
+      host = PSTRING() << "[" << ip_address_.get_ip_str() << "]" << ':' << ip_address_.get_port();
+  } else {
+      host = PSTRING() << ip_address_.get_ip_str() << ':' << ip_address_.get_port();
+  }
+
   string proxy_authorization;
   if (!username_.empty() || !password_.empty()) {
     auto userinfo = PSTRING() << username_ << ':' << password_;


### PR DESCRIPTION
see https://github.com/tdlib/td/issues/1043