### PR TITLE
improve chatInviteLinkInfo docs

### DIFF
--- a/td/generate/scheme/td_api.tl
+++ b/td/generate/scheme/td_api.tl
@@ -777,7 +777,7 @@ chatsNearby users_nearby:vector<chatNearby> supergroups_nearby:vector<chatNearby
 chatInviteLink invite_link:string = ChatInviteLink;
 
 //@description Contains information about a chat invite link
-//@chat_id Chat identifier of the invite link; 0 if the user is not a member of this chat
+//@chat_id Chat identifier of the invite link; 0 if the user is not a member of this chat and if the chat is not public
 //@type Contains information about the type of the chat
 //@title Title of the chat
 //@photo Chat photo; may be null


### PR DESCRIPTION
The `chat_id` field in `chatInviteLinkInfo` claims to be 0 if the user isn't a member of the chat.
In fact, if the user isn't a member of the chat but the chat is public the `chat_id` is not 0 

If you find a better phrasing than mine, go ahead and edit it, I'm not that good with English...