### PR TITLE
Support skipping non-essential parts of the build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,9 +296,13 @@ add_subdirectory(sqlite)
 
 add_subdirectory(tddb)
 
-add_subdirectory(test)
+option(TD_SKIP_TEST "Use \"ON\" to skip building/running the test harness.")
+if (NOT TD_SKIP_TEST)
+  add_subdirectory(test)
+endif()
 
-if (NOT CMAKE_CROSSCOMPILING)
+option(TD_SKIP_BENCHMARK "Use \"ON\" to skip building/running the benchmarks.")
+if (NOT CMAKE_CROSSCOMPILING AND NOT TD_SKIP_BENCHMARK)
   add_subdirectory(benchmark)
 endif()
 
@@ -899,7 +903,8 @@ if (EMSCRIPTEN)
 endif()
 
 #EXECUTABLES
-if (NOT CMAKE_CROSSCOMPILING)
+option(TD_SKIP_TG_CLI "Use \"ON\" to skip building tg_cli.")
+if (NOT CMAKE_CROSSCOMPILING AND NOT TD_SKIP_TG_CLI)
   add_executable(tg_cli td/telegram/cli.cpp ${TL_TD_JSON_SOURCE})
 
   if (NOT READLINE_FOUND)


### PR DESCRIPTION
This significantly speeds up build times for projects which just want to use tdlib as-is.
On a single core this should cut about 5 minutes; on 4 cores it cuts a bit more than a minute.
All this for no measurable cost.

Without skipping:
```
$ cmake -DCMAKE_BUILD_TYPE=Release -DTD_SKIP_BENCHMARK=OFF -DTD_SKIP_TEST=OFF -DTD_SKIP_TG_CLI=OFF ..
( ... regular output ... )
$ time /usr/bin/time make install -j4 DESTDIR=../../td_destdir
( ... regular output ... )
1414.69user 55.66system 7:01.60elapsed 348%CPU (0avgtext+0avgdata 2752144maxresident)k
0inputs+1210120outputs (0major+21767636minor)pagefaults 0swaps
real	7m1,604s
user	23m34,699s
sys	0m55,665s
```

With skipping:
```
$ cmake -DCMAKE_BUILD_TYPE=Release -DTD_SKIP_BENCHMARK=ON -DTD_SKIP_TEST=ON -DTD_SKIP_TG_CLI=ON ..
( ... regular output ... )
$ time /usr/bin/time make install -j4 DESTDIR=../../td_destdir
( ... regular output ... )
1118.16user 42.62system 5:56.22elapsed 325%CPU (0avgtext+0avgdata 2751196maxresident)k
0inputs+891912outputs (0major+17310062minor)pagefaults 0swaps
real	5m56,230s
user	18m38,163s
sys	0m42,629s
```