### PR TITLE
Option "chat_unload_delay" for bots

### DIFF
--- a/td/telegram/MessagesManager.cpp
+++ b/td/telegram/MessagesManager.cpp
@@ -10303,11 +10303,11 @@ void MessagesManager::delete_all_channel_messages_from_user_on_server(ChannelId 
 int32 MessagesManager::get_unload_dialog_delay() const {
   constexpr int32 DIALOG_UNLOAD_DELAY = 60;        // seconds
   constexpr int32 DIALOG_UNLOAD_BOT_DELAY = 1800;  // seconds
-  auto custom_unload_delay = clamp(G()->shared_config().get_option_integer("dialog_unload_delay", -1), -1, 86400);
-  if (custom_unload_delay != -1) {
-    return custom_unload_delay;
+  if (td_->auth_manager_->is_bot()) {
+    return G()->shared_config().get_option_integer("chat_unload_delay", DIALOG_UNLOAD_BOT_DELAY);
+  } else {
+    return DIALOG_UNLOAD_DELAY;
   }
-  return td_->auth_manager_->is_bot() ? DIALOG_UNLOAD_BOT_DELAY : DIALOG_UNLOAD_DELAY;
 }
 
 void MessagesManager::unload_dialog(DialogId dialog_id) {

--- a/td/telegram/MessagesManager.cpp
+++ b/td/telegram/MessagesManager.cpp
@@ -10303,10 +10303,14 @@ void MessagesManager::delete_all_channel_messages_from_user_on_server(ChannelId 
 int32 MessagesManager::get_unload_dialog_delay() const {
   constexpr int32 DIALOG_UNLOAD_DELAY = 60;        // seconds
   constexpr int32 DIALOG_UNLOAD_BOT_DELAY = 1800;  // seconds
-  if (td_->auth_manager_->is_bot()) {
-    return narrow_cast<int32>(G()->shared_config().get_option_integer("chat_unload_delay", DIALOG_UNLOAD_BOT_DELAY));
+
+  auto is_bot = td_->auth_manager_->is_bot();
+  auto default_unload_delay = is_bot ? DIALOG_UNLOAD_BOT_DELAY : DIALOG_UNLOAD_DELAY;
+
+  if (G()->parameters().use_message_db || is_bot) {
+    return narrow_cast<int32>(G()->shared_config().get_option_integer("chat_unload_delay", default_unload_delay));
   } else {
-    return DIALOG_UNLOAD_DELAY;
+    return default_unload_delay;
   }
 }
 

--- a/td/telegram/MessagesManager.cpp
+++ b/td/telegram/MessagesManager.cpp
@@ -10304,7 +10304,7 @@ int32 MessagesManager::get_unload_dialog_delay() const {
   constexpr int32 DIALOG_UNLOAD_DELAY = 60;        // seconds
   constexpr int32 DIALOG_UNLOAD_BOT_DELAY = 1800;  // seconds
   if (td_->auth_manager_->is_bot()) {
-    return G()->shared_config().get_option_integer("chat_unload_delay", DIALOG_UNLOAD_BOT_DELAY);
+    return narrow_cast<int32>(G()->shared_config().get_option_integer("chat_unload_delay", DIALOG_UNLOAD_BOT_DELAY));
   } else {
     return DIALOG_UNLOAD_DELAY;
   }
@@ -13972,7 +13972,7 @@ void MessagesManager::dump_debug_message_op(const Dialog *d, int priority) {
 }
 
 bool MessagesManager::is_message_unload_enabled() const {
-  auto has_custom_unload_time = clamp(G()->shared_config().get_option_integer("unload_messages_after_seconds", -1), -1, 86400) != -1;
+  auto has_custom_unload_time = G()->shared_config().have_option("chat_unload_delay");
   return G()->parameters().use_message_db || td_->auth_manager_->is_bot() || has_custom_unload_time;
 }
 

--- a/td/telegram/MessagesManager.cpp
+++ b/td/telegram/MessagesManager.cpp
@@ -13972,8 +13972,7 @@ void MessagesManager::dump_debug_message_op(const Dialog *d, int priority) {
 }
 
 bool MessagesManager::is_message_unload_enabled() const {
-  auto has_custom_unload_time = G()->shared_config().have_option("chat_unload_delay");
-  return G()->parameters().use_message_db || td_->auth_manager_->is_bot() || has_custom_unload_time;
+  return G()->parameters().use_message_db || td_->auth_manager_->is_bot();
 }
 
 bool MessagesManager::can_unload_message(const Dialog *d, const Message *m) const {

--- a/td/telegram/MessagesManager.cpp
+++ b/td/telegram/MessagesManager.cpp
@@ -10303,6 +10303,10 @@ void MessagesManager::delete_all_channel_messages_from_user_on_server(ChannelId 
 int32 MessagesManager::get_unload_dialog_delay() const {
   constexpr int32 DIALOG_UNLOAD_DELAY = 60;        // seconds
   constexpr int32 DIALOG_UNLOAD_BOT_DELAY = 1800;  // seconds
+  auto custom_unload_delay = clamp(G()->shared_config().get_option_integer("dialog_unload_delay", -1), -1, 86400);
+  if (custom_unload_delay != -1) {
+    return custom_unload_delay;
+  }
   return td_->auth_manager_->is_bot() ? DIALOG_UNLOAD_BOT_DELAY : DIALOG_UNLOAD_DELAY;
 }
 
@@ -13968,7 +13972,8 @@ void MessagesManager::dump_debug_message_op(const Dialog *d, int priority) {
 }
 
 bool MessagesManager::is_message_unload_enabled() const {
-  return G()->parameters().use_message_db || td_->auth_manager_->is_bot();
+  auto has_custom_unload_time = clamp(G()->shared_config().get_option_integer("unload_messages_after_seconds", -1), -1, 86400) != -1;
+  return G()->parameters().use_message_db || td_->auth_manager_->is_bot() || has_custom_unload_time;
 }
 
 bool MessagesManager::can_unload_message(const Dialog *d, const Message *m) const {

--- a/td/telegram/Td.cpp
+++ b/td/telegram/Td.cpp
@@ -7123,6 +7123,9 @@ void Td::on_request(uint64 id, td_api::setOption &request) {
       }
       break;
     case 'd':
+      if (set_integer_option("dialog_unload_delay")) {
+        return;
+      }
       if (!is_bot && set_boolean_option("disable_contact_registered_notifications")) {
         return;
       }

--- a/td/telegram/Td.cpp
+++ b/td/telegram/Td.cpp
@@ -7123,7 +7123,7 @@ void Td::on_request(uint64 id, td_api::setOption &request) {
       }
       break;
     case 'd':
-      if (is_bot && set_integer_option("chat_unload_delay", 60, 86400)) {
+      if ((parameters_.use_message_db || is_bot) && set_integer_option("chat_unload_delay", 60, 86400)) {
         return;
       }
       if (!is_bot && set_boolean_option("disable_contact_registered_notifications")) {

--- a/td/telegram/Td.cpp
+++ b/td/telegram/Td.cpp
@@ -7123,7 +7123,7 @@ void Td::on_request(uint64 id, td_api::setOption &request) {
       }
       break;
     case 'd':
-      if (set_integer_option("dialog_unload_delay")) {
+      if (is_bot && set_integer_option("chat_unload_delay", 60, 86400)) {
         return;
       }
       if (!is_bot && set_boolean_option("disable_contact_registered_notifications")) {


### PR DESCRIPTION
This option allows to override the default dialog unload delay.

The allowed range is from 0 to 86400 seconds (1 day).
Setting the value -1 restores the default behavior.
If the option is not set the default value will be -1, so it will use the default behavior.
