### PR TITLE
Fix java example build

### DIFF
--- a/example/java/org/drinkless/tdlib/example/Example.java
+++ b/example/java/org/drinkless/tdlib/example/Example.java
@@ -305,7 +305,7 @@ public final class Example {
     public static void main(String[] args) throws InterruptedException {
         // disable TDLib log
         Client.execute(new TdApi.SetLogVerbosityLevel(0));
-        if (Client.execute(new TdApi.SetLogStream(new TdApi.LogStreamFile("tdlib.log", 1 << 27))) instanceof TdApi.Error) {
+        if (Client.execute(new TdApi.SetLogStream(new TdApi.LogStreamFile("tdlib.log", 1 << 27, true))) instanceof TdApi.Error) {
             throw new IOError(new IOException("Write access to the current directory is required"));
         }
 


### PR DESCRIPTION
## Introduction

Java build failed with error 
```
/Users/nikitakulikov/private/tdlib-lionzxy/example/java/org/drinkless/tdlib/example/Example.java:308: error: no suitable constructor found for LogStreamFile(String,int)
        if (Client.execute(new TdApi.SetLogStream(new TdApi.LogStreamFile("tdlib.log", 1 << 27))) instanceof TdApi.Error) {
                                                  ^
    constructor LogStreamFile.LogStreamFile() is not applicable
      (actual and formal argument lists differ in length)
    constructor LogStreamFile.LogStreamFile(String,long,boolean) is not applicable
      (actual and formal argument lists differ in length)
Note: /Users/nikitakulikov/private/tdlib-lionzxy/example/java/org/drinkless/tdlib/Client.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
1 error
make[2]: *** [CMakeFiles/build_java] Error 1
make[1]: *** [CMakeFiles/build_java.dir/all] Error 2
```

## What I do

Add a third argument in constructor init - `redirect_stderr`

## What I don't

I do not fix any example on another language, but I see that it have similar problem
