### PR TITLE
Minor bug fix in the cpp example

### DIFF
--- a/example/cpp/td_example.cpp
+++ b/example/cpp/td_example.cpp
@@ -257,7 +257,7 @@ class TdExample {
             [this](td_api::authorizationStateWaitPassword &) {
               std::cout << "Enter authentication password: " << std::flush;
               std::string password;
-              std::cin >> password;
+              std::getline(std::cin, line);
               send_query(td_api::make_object<td_api::checkAuthenticationPassword>(password),
                          create_authentication_query_handler());
             },


### PR DESCRIPTION
`std::cin` only reads the first word from the command-line, while Telegram passwords can contain spaces