### PR TITLE
Remove extra include dir part.

### DIFF
--- a/td/telegram/logevent/LogEventHelper.cpp
+++ b/td/telegram/logevent/LogEventHelper.cpp
@@ -9,7 +9,7 @@
 #include "td/telegram/Global.h"
 #include "td/telegram/TdDb.h"
 
-#include "tddb/td/db/binlog/BinlogHelper.h"
+#include "td/db/binlog/BinlogHelper.h"
 
 #include "td/utils/logging.h"
 #include "td/utils/Status.h"


### PR DESCRIPTION
Looks like an artifact of copy paste or something like that.
It forces us to add additional include directory to the root of tdlib sources `-I.` near with correct `-Itddb`.
Grep shows that this is the single source file with `/td/` (or `\/td\/`) pattern that adds something before root `td/` part.