### PR TITLE
change rust-tdlib link

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -172,8 +172,10 @@ TDLib can be used from the Rust programming language through the [JSON](https://
 See [tdlib-rs](https://github.com/agnipau/tdlib-rs), which contains automatically generated classes for all TDLib API methods and objects.
 
 See [rtdlib](https://github.com/fewensa/rtdlib), [tdlib-rs](https://github.com/d653/tdlib-rs), [tdlib-futures](https://github.com/yuri91/tdlib-futures),
-[tdlib-sys](https://github.com/nuxeh/tdlib-sys), [rust-tdlib](https://github.com/lattenwald/rust-tdlib), or
+[tdlib-sys](https://github.com/nuxeh/tdlib-sys), or
 [tdjson-rs](https://github.com/mersinvald/tdjson-rs) for examples of TDLib Rust bindings.
+
+You can use [rust-tdlib](https://github.com/aCLr/rust-tdlib) if you need high-level client implementation.
 
 <a name="erlang"></a>
 ## Using TDLib in Erlang projects


### PR DESCRIPTION
Приветствую.

Пару часов назад релизнул [rust-tdlib 0.2.0](https://crates.io/crates/rust-tdlib) и только после этого чисто случайно наткнулся на [одноименную библиотеку](https://github.com/lattenwald/rust-tdlib), и то только потому, что она упомянута здесь: библиотеки нет на crates.io, поэтому с названием и не возникло проблем.

Я написал разработчику библиотеки, указанной в ридми и он не против изменить ссылку на мой вариант (можете убедиться в этом, поискав на сервере телеграма :D):
```
Alexander, [17.02.21 12:09]
Со мной связались за два года про эту либу один раз, ты второй.

Alexander, [17.02.21 12:09]
Клиент, вероятно, людям удобнее

Alexander, [17.02.21 12:09]
Заменяй
```.