### PR TITLE
Fix memory leak of "handlers_" in cpp example

### DIFF
--- a/example/cpp/td_example.cpp
+++ b/example/cpp/td_example.cpp
@@ -172,6 +172,7 @@ class TdExample {
     auto it = handlers_.find(response.request_id);
     if (it != handlers_.end()) {
       it->second(std::move(response.object));
+      handlers_.erase(it);
     }
   }
 


### PR DESCRIPTION
Fix #1461