### PR TITLE
Clarify importance of generated files on non-macOS builds

### DIFF
--- a/example/ios/README.md
+++ b/example/ios/README.md
@@ -13,7 +13,8 @@ To compile `TDLib` you will need to:
 ```
 brew install gperf cmake coreutils
 ```
-* If you don't want to build `TDLib` for macOS, you **must** pregenerate required source code files using `CMake` prepare_cross_compiling target:
+* `TDLib` requires some generated source code files. Those files generates automatically if you're building `TDLib` for macOS.
+If you don't want to build `TDLib` for macOS _or_ building it separatelly _or_ building it not in first place _(e.g. in order: iOS, watchOS, macOS)_, you **must** pregenerate required source code files using `CMake` prepare_cross_compiling target:
 ```
 cd <path to TDLib sources>
 mkdir native-build

--- a/example/ios/README.md
+++ b/example/ios/README.md
@@ -13,7 +13,7 @@ To compile `TDLib` you will need to:
 ```
 brew install gperf cmake coreutils
 ```
-* If you don't want to build `TDLib` for macOS, you can pregenerate required source code files using `CMake` prepare_cross_compiling target:
+* If you don't want to build `TDLib` for macOS, you **must** pregenerate required source code files using `CMake` prepare_cross_compiling target:
 ```
 cd <path to TDLib sources>
 mkdir native-build

--- a/example/ios/README.md
+++ b/example/ios/README.md
@@ -13,7 +13,7 @@ To compile `TDLib` you will need to:
 ```
 brew install gperf cmake coreutils
 ```
-* If you don't want to build `TDLib` for macOS, you **must** pregenerate required source code files using `CMake` prepare_cross_compiling target:
+* If you don't want to build `TDLib` for macOS first, you **must** pregenerate required source code files using `CMake` prepare_cross_compiling target:
 ```
 cd <path to TDLib sources>
 mkdir native-build

--- a/example/ios/README.md
+++ b/example/ios/README.md
@@ -13,8 +13,7 @@ To compile `TDLib` you will need to:
 ```
 brew install gperf cmake coreutils
 ```
-* `TDLib` requires some generated source code files. Those files generates automatically if you're building `TDLib` for macOS.
-If you don't want to build `TDLib` for macOS _or_ building it separatelly _or_ building it not in first place _(e.g. in order: iOS, watchOS, macOS)_, you **must** pregenerate required source code files using `CMake` prepare_cross_compiling target:
+* If you don't want to build `TDLib` for macOS, you **must** pregenerate required source code files using `CMake` prepare_cross_compiling target:
 ```
 cd <path to TDLib sources>
 mkdir native-build


### PR DESCRIPTION
I've tried to build `TDLib`for iOS and found out that some files are generated only for macOS builds. 

I want to propose a change for docs because i've naturally skipped pregeneration docs part due to weak "`can`" word. 

I've tried to build `TDLib` for iOS only and failed because some **required** files were missing.
So we definitely **`must`** pregenerate files if we don't want to build macOS lib in a same flow (pipeline, etc)


Example behaviour below

### ❌ `./build.sh` platforms="iOS"
error, unable to find some generated tdutils file
![image](https://user-images.githubusercontent.com/24507532/124884632-223a2580-dfdb-11eb-9505-622f28c2ff7d.png)


### ✅ `./build.sh` platforms="macOS"
### ✅ `./build.sh` platforms="macOS iOS watchOS"
sources generated "on the fly" in same build phase
![image](https://user-images.githubusercontent.com/24507532/124884365-e0a97a80-dfda-11eb-9513-c6d5eca6e6a4.png)



### ✅ prepare_cross_compiling
sources generated with separate command
![image](https://user-images.githubusercontent.com/24507532/124884822-51e92d80-dfdb-11eb-9642-c9ab543ce74f.png)
