### PR TITLE
CMakeLists: show error in case libraries not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,7 @@ if (NOT CMAKE_CROSSCOMPILING)
 endif()
 
 if (NOT OPENSSL_FOUND)
-  message(WARNING "Can't find OpenSSL: stop TDLib building")
+  message(FATAL_ERROR "Can't find OpenSSL: stop TDLib building")
   return()
 endif()
 
@@ -181,12 +181,12 @@ if (NOT ZLIB_FOUND)
   find_package(ZLIB)
 endif()
 if (NOT ZLIB_FOUND)
-  message(WARNING "Can't find zlib: stop TDLib building")
+  message(FATAL_ERROR "Can't find zlib: stop TDLib building")
   return()
 endif()
 
 if (NOT TDUTILS_MIME_TYPE)
-  message(WARNING "Option TDUTILS_MIME_TYPE must not be disabled: stop TDLib building")
+  message(FATAL_ERROR "Option TDUTILS_MIME_TYPE must not be disabled: stop TDLib building")
   return()
 endif()
 


### PR DESCRIPTION
This will cause CMake to exit with an error exit code instead of returning zero.

I've found it returns zero after a recent change on GitHub Actions where they've broken OpenSSL detection by the default TDLib build scripts: see https://github.com/actions/virtual-environments/issues/4195.

Without this change, my GitHub Actions build script which calls `cmake && cmake --build` ran successfully but just not generated any binaries on macOS.