### PR TITLE
Add missing 'struct' keywords for tdc headers

### DIFF
--- a/td/generate/tl_writer_c.h
+++ b/td/generate/tl_writer_c.h
@@ -242,7 +242,7 @@ class TlWriterCCommon final : public tl::TL_writer {
              "TDC_VECTOR(Int,int)\n"
              "TDC_VECTOR(Long,long long)\n"
              "TDC_VECTOR(String,char *)\n"
-             "TDC_VECTOR(Bytes,TdBytes)\n"
+             "TDC_VECTOR(Bytes,struct TdBytes)\n"
              "struct TdStackStorerMethods {\n"
              "  void (*pack_string)(const char *s);\n"
              "  void (*pack_bytes)(const unsigned char *s, int len);\n"

--- a/td/telegram/td_c_client.h
+++ b/td/telegram/td_c_client.h
@@ -19,22 +19,22 @@ struct TdBytes TdCreateObjectBytes(unsigned char *data, int len);
 
 struct TdRequest {
   long long request_id;
-  TdFunction *function;
+  struct TdFunction *function;
 };
 
 struct TdResponse {
   long long request_id;
   int client_id;
-  TdObject *object;
+  struct TdObject *object;
 };
 
 int TdCClientCreateId();
 
 void TdCClientSend(int client_id, struct TdRequest request);
 
-TdResponse TdCClientReceive(double timeout);
+struct TdResponse TdCClientReceive(double timeout);
 
-TdObject *TdCClientExecute(TdFunction *function);
+struct TdObject *TdCClientExecute(struct TdFunction *function);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Some structs do not have typedef aliases, but their references forget to put 'struct' keywords when referencing them, so they cause compiling issues.

This commit adds the missing 'struct' keywords so TDLib C headers could compile successfully.