### PR TITLE
MacOS OpenSSL path fix

### DIFF
--- a/build.html
+++ b/build.html
@@ -957,7 +957,7 @@ function onOptionsChanged() {
 
     cmake_init_options = getBacicCmakeInitOptions();
     if (os_mac) {
-      cmake_init_options.push('-DOPENSSL_ROOT_DIR=/usr/local/opt/openssl/');
+      cmake_init_options.push('-DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@3/');
     }
     if (install_dir) {
       cmake_init_options.push('-DCMAKE_INSTALL_PREFIX:PATH=' + install_dir);


### PR DESCRIPTION
Fixed MacOS OpenSSL path. If install openssl using brew - it installed to /opt/homebrew/opt/openssl@3/