### PR TITLE
Fix typos regarding much and many

### DIFF
--- a/CMake/TdSetUpCompiler.cmake
+++ b/CMake/TdSetUpCompiler.cmake
@@ -134,7 +134,7 @@ function(td_set_up_compiler)
   endif()
 
   if (GCC AND NOT (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0))
-    add_cxx_compiler_flag("-Wno-maybe-uninitialized")  # too much false positives
+    add_cxx_compiler_flag("-Wno-maybe-uninitialized")  # too many false positives
   endif()
   if (WIN32 AND GCC AND NOT (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0))
     # warns about casts of function pointers returned by GetProcAddress

--- a/td/generate/scheme/td_api.tl
+++ b/td/generate/scheme/td_api.tl
@@ -2835,7 +2835,7 @@ checkChatUsernameResultUsernameInvalid = CheckChatUsernameResult;
 //@description The username is occupied
 checkChatUsernameResultUsernameOccupied = CheckChatUsernameResult;
 
-//@description The user has too much chats with username, one of them must be made private first
+//@description The user has too many chats with username, one of them must be made private first
 checkChatUsernameResultPublicChatsTooMuch = CheckChatUsernameResult;
 
 //@description The user can't be a member of a public supergroup

--- a/td/mtproto/SessionConnection.cpp
+++ b/td/mtproto/SessionConnection.cpp
@@ -935,7 +935,7 @@ void SessionConnection::flush_packet() {
       v.clear();
       return result;
     }
-    LOG(WARNING) << "Too much message identifiers in container " << name << ": " << v.size() << " instead of " << size;
+    LOG(WARNING) << "Too many message identifiers in container " << name << ": " << v.size() << " instead of " << size;
     vector<int64> result(v.end() - size, v.end());
     v.resize(v.size() - size);
     return result;

--- a/td/telegram/MessagesManager.cpp
+++ b/td/telegram/MessagesManager.cpp
@@ -24527,7 +24527,7 @@ Result<vector<MessageId>> MessagesManager::send_message_group(
     tl_object_ptr<td_api::messageSendOptions> &&options,
     vector<tl_object_ptr<td_api::InputMessageContent>> &&input_message_contents) {
   if (input_message_contents.size() > MAX_GROUPED_MESSAGES) {
-    return Status::Error(400, "Too much messages to send as an album");
+    return Status::Error(400, "Too many messages to send as an album");
   }
   if (input_message_contents.empty()) {
     return Status::Error(400, "There are no messages to send");
@@ -27039,7 +27039,7 @@ Result<MessagesManager::ForwardedMessages> MessagesManager::get_forwarded_messag
     vector<MessageCopyOptions> &&copy_options) {
   CHECK(copy_options.size() == message_ids.size());
   if (message_ids.size() > 100) {  // TODO replace with const from config or implement mass-forward
-    return Status::Error(400, "Too much messages to forward");
+    return Status::Error(400, "Too many messages to forward");
   }
   if (message_ids.empty()) {
     return Status::Error(400, "There are no messages to forward");

--- a/td/telegram/NotificationManager.cpp
+++ b/td/telegram/NotificationManager.cpp
@@ -3255,7 +3255,7 @@ Status NotificationManager::process_push_notification_payload(string payload, bo
     loc_args.clear();
   }
   if (loc_args.size() > 1) {
-    return Status::Error("Receive too much arguments");
+    return Status::Error("Receive too many arguments");
   }
 
   if (loc_args.size() == 1) {

--- a/td/telegram/PollManager.cpp
+++ b/td/telegram/PollManager.cpp
@@ -1542,7 +1542,7 @@ PollId PollManager::on_get_poll(PollId poll_id, tl_object_ptr<telegram_api::poll
       }
       auto max_voter_count = std::numeric_limits<int32>::max() / narrow_cast<int32>(poll->options.size()) - 2;
       if (poll_result->voters_ > max_voter_count) {
-        LOG(ERROR) << "Have too much " << poll_result->voters_ << " poll voters for an option in " << poll_id;
+        LOG(ERROR) << "Have too many " << poll_result->voters_ << " poll voters for an option in " << poll_id;
         poll_result->voters_ = max_voter_count;
       }
       if (poll_result->voters_ != option.voter_count) {

--- a/td/telegram/net/Session.cpp
+++ b/td/telegram/net/Session.cpp
@@ -753,7 +753,7 @@ Status Session::on_message_result_ok(uint64 id, BufferSlice packet, size_t origi
         auto dropped_size = dropped_size_;
         dropped_size_ = 0;
         return Status::Error(
-            2, PSLICE() << "Too much dropped packets " << tag("total_size", format::as_size(dropped_size)));
+            2, PSLICE() << "Too many dropped packets " << tag("total_size", format::as_size(dropped_size)));
       }
     }
     return Status::OK();
@@ -1158,8 +1158,8 @@ void Session::connection_open_finish(ConnectionInfo *info,
   info->created_at_ = Time::now_cached();
   info->wakeup_at_ = Time::now_cached() + 10;
   if (unknown_queries_.size() > MAX_INFLIGHT_QUERIES) {
-    LOG(ERROR) << "With current limits `Too much queries with unknown state` error must be impossible";
-    on_session_failed(Status::Error("Too much queries with unknown state"));
+    LOG(ERROR) << "With current limits `Too many queries with unknown state` error must be impossible";
+    on_session_failed(Status::Error("Too many queries with unknown state"));
     return;
   }
   if (info->ask_info_) {

--- a/tdnet/td/net/HttpHeaderCreator.h
+++ b/tdnet/td/net/HttpHeaderCreator.h
@@ -57,7 +57,7 @@ class HttpHeaderCreator {
       sb_ << content;
     }
     if (sb_.is_error()) {
-      return Status::Error("Too much headers");
+      return Status::Error("Too many headers");
     }
     return sb_.as_cslice();
   }

--- a/tdnet/td/net/HttpReader.cpp
+++ b/tdnet/td/net/HttpReader.cpp
@@ -200,7 +200,7 @@ Result<size_t> HttpReader::read_next(HttpQuery *query, bool can_be_slow) {
       case State::ReadArgs: {
         auto size = content_->size();
         if (size > MAX_TOTAL_PARAMETERS_LENGTH - total_parameters_length_) {
-          return Status::Error(413, "Request Entity Too Large: too much parameters");
+          return Status::Error(413, "Request Entity Too Large: too many parameters");
         }
 
         if (flow_sink_.is_ready()) {
@@ -406,7 +406,7 @@ Result<bool> HttpReader::parse_multipart_form_data(bool can_be_slow) {
           if (has_file_name_) {
             // file
             if (query_->files_.size() == max_files_) {
-              return Status::Error(413, "Request Entity Too Large: too much files attached");
+              return Status::Error(413, "Request Entity Too Large: too many files attached");
             }
             auto file = open_temp_file(file_name_);
             if (file.is_error()) {
@@ -432,7 +432,7 @@ Result<bool> HttpReader::parse_multipart_form_data(bool can_be_slow) {
       case FormDataParseState::ReadPartValue:
         if (find_boundary(content_->clone(), boundary_, form_data_read_length_)) {
           if (total_parameters_length_ + form_data_read_length_ > MAX_TOTAL_PARAMETERS_LENGTH) {
-            return Status::Error(413, "Request Entity Too Large: too much parameters in form data");
+            return Status::Error(413, "Request Entity Too Large: too many parameters in form data");
           }
 
           query_->container_.emplace_back(content_->cut_head(form_data_read_length_).move_as_buffer_slice());
@@ -460,7 +460,7 @@ Result<bool> HttpReader::parse_multipart_form_data(bool can_be_slow) {
         CHECK(content_->size() < form_data_read_length_ + boundary_.size());
 
         if (total_parameters_length_ + form_data_read_length_ > MAX_TOTAL_PARAMETERS_LENGTH) {
-          return Status::Error(413, "Request Entity Too Large: too much parameters in form data");
+          return Status::Error(413, "Request Entity Too Large: too many parameters in form data");
         }
         return false;
       case FormDataParseState::ReadFile: {
@@ -594,7 +594,7 @@ Status HttpReader::parse_url(MutableSlice url) {
 Status HttpReader::parse_parameters(MutableSlice parameters) {
   total_parameters_length_ += parameters.size();
   if (total_parameters_length_ > MAX_TOTAL_PARAMETERS_LENGTH) {
-    return Status::Error(413, "Request Entity Too Large: too much parameters");
+    return Status::Error(413, "Request Entity Too Large: too many parameters");
   }
   LOG(DEBUG) << "Parse parameters: \"" << parameters << "\"";
 
@@ -620,7 +620,7 @@ Status HttpReader::parse_json_parameters(MutableSlice parameters) {
 
   total_parameters_length_ += parameters.size();
   if (total_parameters_length_ > MAX_TOTAL_PARAMETERS_LENGTH) {
-    return Status::Error(413, "Request Entity Too Large: too much parameters");
+    return Status::Error(413, "Request Entity Too Large: too many parameters");
   }
   LOG(DEBUG) << "Parse JSON parameters: \"" << parameters << "\"";
 

--- a/tdutils/td/utils/OptionParser.cpp
+++ b/tdutils/td/utils/OptionParser.cpp
@@ -196,7 +196,7 @@ Result<vector<char *>> OptionParser::run_impl(int argc, char *argv[], int expect
       return Status::Error("Unexpected non-option parameters specified");
     }
     if (non_options.size() > static_cast<size_t>(expected_non_option_count)) {
-      return Status::Error("Too much non-option parameters specified");
+      return Status::Error("Too many non-option parameters specified");
     } else {
       return Status::Error("Too few non-option parameters specified");
     }


### PR DESCRIPTION
There was an error message that incorrectly said ”too much parameters“ while it should be “too many parameters” since parameters are countable. This PR fixes it.

Along the way, it also fixes the same mistake in a bunch of other places. However, only comments, documentation, logs, and error messages are touched. For example, `checkChatUsernameResultPublicChatsTooMuch` is left unchanged in order to avoid a breaking change.