### PR TITLE
Add more Settings links

### DIFF
--- a/td/generate/scheme/td_api.tl
+++ b/td/generate/scheme/td_api.tl
@@ -3370,6 +3370,12 @@ internalLinkTypeUserPhoneNumber phone_number:string = InternalLinkType;
 //@is_live_stream True, if the video chat is expected to be a live stream in a channel or a broadcast group
 internalLinkTypeVideoChat chat_username:string invite_hash:string is_live_stream:Bool = InternalLinkType;
 
+//@description The link is a link to the language settings section of the app
+internalLinkTypeLanguageSettings = InternalLinkType;
+
+//@description The link is a link to the privacy settings section of the app
+internalLinkTypePrivacySettings = InternalLinkType;
+
 
 //@description Contains an HTTPS link to a message in a supergroup or channel @link Message link @is_public True, if the link will work for non-members of the chat
 messageLink link:string is_public:Bool = MessageLink;

--- a/td/generate/scheme/td_api.tl
+++ b/td/generate/scheme/td_api.tl
@@ -3317,6 +3317,9 @@ internalLinkTypeGame bot_username:string game_short_name:string = InternalLinkTy
 //@description The link is a link to a language pack. Call getLanguagePackInfo with the given language pack identifier to process the link @language_pack_id Language pack identifier
 internalLinkTypeLanguagePack language_pack_id:string = InternalLinkType;
 
+//@description The link is a link to the language settings section of the app
+internalLinkTypeLanguageSettings = InternalLinkType;
+
 //@description The link is a link to a Telegram message. Call getMessageLinkInfo with the given URL to process the link @url URL to be passed to getMessageLinkInfo
 internalLinkTypeMessage url:string = InternalLinkType;
 
@@ -3332,6 +3335,9 @@ internalLinkTypePassportDataRequest bot_user_id:int53 scope:string public_key:st
 //@description The link can be used to confirm ownership of a phone number to prevent account deletion. Call sendPhoneNumberConfirmationCode with the given hash and phone number to process the link
 //@hash Hash value from the link @phone_number Phone number value from the link
 internalLinkTypePhoneNumberConfirmation hash:string phone_number:string = InternalLinkType;
+
+//@description The link is a link to the privacy and security settings section of the app
+internalLinkTypePrivacyAndSecuritySettings = InternalLinkType;
 
 //@description The link is a link to a proxy. Call addProxy with the given parameters to process the link and add the proxy
 //@server Proxy server IP address @port Proxy server port @type Type of the proxy
@@ -3369,12 +3375,6 @@ internalLinkTypeUserPhoneNumber phone_number:string = InternalLinkType;
 //@chat_username Username of the chat with the video chat @invite_hash If non-empty, invite hash to be used to join the video chat without being muted by administrators
 //@is_live_stream True, if the video chat is expected to be a live stream in a channel or a broadcast group
 internalLinkTypeVideoChat chat_username:string invite_hash:string is_live_stream:Bool = InternalLinkType;
-
-//@description The link is a link to the language settings section of the app
-internalLinkTypeLanguageSettings = InternalLinkType;
-
-//@description The link is a link to the privacy settings section of the app
-internalLinkTypePrivacySettings = InternalLinkType;
 
 
 //@description Contains an HTTPS link to a message in a supergroup or channel @link Message link @is_public True, if the link will work for non-members of the chat

--- a/td/telegram/LinkManager.cpp
+++ b/td/telegram/LinkManager.cpp
@@ -224,6 +224,12 @@ class LinkManager::InternalLinkLanguage final : public InternalLink {
   }
 };
 
+class LinkManager::InternalLinkLanguageSettings final : public InternalLink {
+  td_api::object_ptr<td_api::InternalLinkType> get_internal_link_type_object() const final {
+    return td_api::make_object<td_api::internalLinkTypeLanguageSettings>();
+  }
+};
+
 class LinkManager::InternalLinkMessage final : public InternalLink {
   string url_;
 
@@ -303,6 +309,12 @@ class LinkManager::InternalLinkProxy final : public InternalLink {
  public:
   InternalLinkProxy(string server, int32 port, td_api::object_ptr<td_api::ProxyType> type)
       : server_(std::move(server)), port_(port), type_(std::move(type)) {
+  }
+};
+
+class LinkManager::InternalLinkPrivacyAndSecuritySettings final : public InternalLink {
+  td_api::object_ptr<td_api::InternalLinkType> get_internal_link_type_object() const final {
+    return td_api::make_object<td_api::internalLinkTypePrivacyAndSecuritySettings>();
   }
 };
 
@@ -404,18 +416,6 @@ class LinkManager::InternalLinkVoiceChat final : public InternalLink {
       : dialog_username_(std::move(dialog_username))
       , invite_hash_(std::move(invite_hash))
       , is_live_stream_(is_live_stream) {
-  }
-};
-
-class LinkManager::InternalLinkLanguageSettings final : public InternalLink {
-  td_api::object_ptr<td_api::InternalLinkType> get_internal_link_type_object() const final {
-    return td_api::make_object<td_api::internalLinkTypeLanguageSettings>();
-  }
-};
-
-class LinkManager::InternalLinkPrivacySettings final : public InternalLink {
-  td_api::object_ptr<td_api::InternalLinkType> get_internal_link_type_object() const final {
-    return td_api::make_object<td_api::internalLinkTypePrivacySettings>();
   }
 };
 
@@ -871,17 +871,17 @@ unique_ptr<LinkManager::InternalLink> LinkManager::parse_tg_link_query(Slice que
       // settings/folders
       return td::make_unique<InternalLinkFilterSettings>();
     }
-    if (path.size() == 2 && (path[1] == "themes" || path[1] == "theme")) {
-      // settings/theme(s)
-      return td::make_unique<InternalLinkThemeSettings>();
-    }
     if (path.size() == 2 && path[1] == "language") {
       // settings/language
       return td::make_unique<InternalLinkLanguageSettings>();
     }
     if (path.size() == 2 && path[1] == "privacy") {
       // settings/privacy
-      return td::make_unique<InternalLinkPrivacySettings>();
+      return td::make_unique<InternalLinkPrivacyAndSecuritySettings>();
+    }
+    if (path.size() == 2 && path[1] == "themes") {
+      // settings/themes
+      return td::make_unique<InternalLinkThemeSettings>();
     }
     // settings
     return td::make_unique<InternalLinkSettings>();

--- a/td/telegram/LinkManager.cpp
+++ b/td/telegram/LinkManager.cpp
@@ -407,6 +407,18 @@ class LinkManager::InternalLinkVoiceChat final : public InternalLink {
   }
 };
 
+class LinkManager::InternalLinkLanguageSettings final : public InternalLink {
+  td_api::object_ptr<td_api::InternalLinkType> get_internal_link_type_object() const final {
+    return td_api::make_object<td_api::internalLinkTypeLanguageSettings>();
+  }
+};
+
+class LinkManager::InternalLinkPrivacySettings final : public InternalLink {
+  td_api::object_ptr<td_api::InternalLinkType> get_internal_link_type_object() const final {
+    return td_api::make_object<td_api::internalLinkTypePrivacySettings>();
+  }
+};
+
 class GetDeepLinkInfoQuery final : public Td::ResultHandler {
   Promise<td_api::object_ptr<td_api::deepLinkInfo>> promise_;
 
@@ -859,9 +871,17 @@ unique_ptr<LinkManager::InternalLink> LinkManager::parse_tg_link_query(Slice que
       // settings/folders
       return td::make_unique<InternalLinkFilterSettings>();
     }
-    if (path.size() == 2 && path[1] == "themes") {
-      // settings/themes
+    if (path.size() == 2 && (path[1] == "themes" || path[1] == "theme")) {
+      // settings/theme(s)
       return td::make_unique<InternalLinkThemeSettings>();
+    }
+    if (path.size() == 2 && path[1] == "language") {
+      // settings/language
+      return td::make_unique<InternalLinkLanguageSettings>();
+    }
+    if (path.size() == 2 && path[1] == "privacy") {
+      // settings/privacy
+      return td::make_unique<InternalLinkPrivacySettings>();
     }
     // settings
     return td::make_unique<InternalLinkSettings>();

--- a/td/telegram/LinkManager.cpp
+++ b/td/telegram/LinkManager.cpp
@@ -280,6 +280,12 @@ class LinkManager::InternalLinkPassportDataRequest final : public InternalLink {
   }
 };
 
+class LinkManager::InternalLinkPrivacyAndSecuritySettings final : public InternalLink {
+  td_api::object_ptr<td_api::InternalLinkType> get_internal_link_type_object() const final {
+    return td_api::make_object<td_api::internalLinkTypePrivacyAndSecuritySettings>();
+  }
+};
+
 class LinkManager::InternalLinkProxy final : public InternalLink {
   string server_;
   int32 port_;
@@ -309,12 +315,6 @@ class LinkManager::InternalLinkProxy final : public InternalLink {
  public:
   InternalLinkProxy(string server, int32 port, td_api::object_ptr<td_api::ProxyType> type)
       : server_(std::move(server)), port_(port), type_(std::move(type)) {
-  }
-};
-
-class LinkManager::InternalLinkPrivacyAndSecuritySettings final : public InternalLink {
-  td_api::object_ptr<td_api::InternalLinkType> get_internal_link_type_object() const final {
-    return td_api::make_object<td_api::internalLinkTypePrivacyAndSecuritySettings>();
   }
 };
 

--- a/td/telegram/LinkManager.h
+++ b/td/telegram/LinkManager.h
@@ -92,9 +92,11 @@ class LinkManager final : public Actor {
   class InternalLinkFilterSettings;
   class InternalLinkGame;
   class InternalLinkLanguage;
+  class InternalLinkLanguageSettings;
   class InternalLinkMessage;
   class InternalLinkMessageDraft;
   class InternalLinkPassportDataRequest;
+  class InternalLinkPrivacyAndSecuritySettings;
   class InternalLinkProxy;
   class InternalLinkPublicDialog;
   class InternalLinkQrCodeAuthentication;
@@ -106,8 +108,6 @@ class LinkManager final : public Actor {
   class InternalLinkUnsupportedProxy;
   class InternalLinkUserPhoneNumber;
   class InternalLinkVoiceChat;
-  class InternalLinkLanguageSettings;
-  class InternalLinkPrivacySettings;
 
   struct LinkInfo {
     bool is_internal_ = false;

--- a/td/telegram/LinkManager.h
+++ b/td/telegram/LinkManager.h
@@ -106,6 +106,8 @@ class LinkManager final : public Actor {
   class InternalLinkUnsupportedProxy;
   class InternalLinkUserPhoneNumber;
   class InternalLinkVoiceChat;
+  class InternalLinkLanguageSettings;
+  class InternalLinkPrivacySettings;
 
   struct LinkInfo {
     bool is_internal_ = false;

--- a/test/link.cpp
+++ b/test/link.cpp
@@ -180,6 +180,12 @@ TEST(Link, parse_internal_link) {
   auto video_chat = [](const td::string &chat_username, const td::string &invite_hash, bool is_live_stream) {
     return td::td_api::make_object<td::td_api::internalLinkTypeVideoChat>(chat_username, invite_hash, is_live_stream);
   };
+  auto language_settings = [] {
+    return td::td_api::make_object<td::td_api::internalLinkTypeLanguageSettings>();
+  };
+  auto privacy_settings = [] {
+    return td::td_api::make_object<td::td_api::internalLinkTypePrivacySettings>();
+  };
 
   parse_internal_link("t.me/levlam/1", message("tg:resolve?domain=levlam&post=1"));
   parse_internal_link("telegram.me/levlam/1", message("tg:resolve?domain=levlam&post=1"));
@@ -686,4 +692,7 @@ TEST(Link, parse_internal_link) {
   parse_internal_link("tg://settings/change_number", change_phone_number());
   parse_internal_link("tg://settings/folders", filter_settings());
   parse_internal_link("tg://settings/filters", settings());
+  parse_internal_link("tg://settings/theme", theme_settings());
+  parse_internal_link("tg://settings/language", language_settings());
+  parse_internal_link("tg://settings/privacy", privacy_settings());
 }

--- a/test/link.cpp
+++ b/test/link.cpp
@@ -125,6 +125,9 @@ TEST(Link, parse_internal_link) {
   auto language_pack = [](const td::string &language_pack_name) {
     return td::td_api::make_object<td::td_api::internalLinkTypeLanguagePack>(language_pack_name);
   };
+  auto language_settings = [] {
+    return td::td_api::make_object<td::td_api::internalLinkTypeLanguageSettings>();
+  };
   auto message = [](const td::string &url) {
     return td::td_api::make_object<td::td_api::internalLinkTypeMessage>(url);
   };
@@ -140,6 +143,9 @@ TEST(Link, parse_internal_link) {
   };
   auto phone_number_confirmation = [](const td::string &hash, const td::string &phone_number) {
     return td::td_api::make_object<td::td_api::internalLinkTypePhoneNumberConfirmation>(hash, phone_number);
+  };
+  auto privacy_and_security_settings = [] {
+    return td::td_api::make_object<td::td_api::internalLinkTypePrivacyAndSecuritySettings>();
   };
   auto proxy_mtproto = [](const td::string &server, td::int32 port, const td::string &secret) {
     return td::td_api::make_object<td::td_api::internalLinkTypeProxy>(
@@ -179,12 +185,6 @@ TEST(Link, parse_internal_link) {
   };
   auto video_chat = [](const td::string &chat_username, const td::string &invite_hash, bool is_live_stream) {
     return td::td_api::make_object<td::td_api::internalLinkTypeVideoChat>(chat_username, invite_hash, is_live_stream);
-  };
-  auto language_settings = [] {
-    return td::td_api::make_object<td::td_api::internalLinkTypeLanguageSettings>();
-  };
-  auto privacy_settings = [] {
-    return td::td_api::make_object<td::td_api::internalLinkTypePrivacySettings>();
   };
 
   parse_internal_link("t.me/levlam/1", message("tg:resolve?domain=levlam&post=1"));
@@ -692,7 +692,6 @@ TEST(Link, parse_internal_link) {
   parse_internal_link("tg://settings/change_number", change_phone_number());
   parse_internal_link("tg://settings/folders", filter_settings());
   parse_internal_link("tg://settings/filters", settings());
-  parse_internal_link("tg://settings/theme", theme_settings());
   parse_internal_link("tg://settings/language", language_settings());
-  parse_internal_link("tg://settings/privacy", privacy_settings());
+  parse_internal_link("tg://settings/privacy", privacy_and_security_settings());
 }


### PR DESCRIPTION
This pull request adds support for more `tg://settings` links:
* `tg://settings/theme` - from the iOS client
* `tg://settings/language` - from Telegram Desktop
* `tg://settings/privacy` - from the native macOS client

These could be defined "non-standard" links, but some of the already implemented ones (such as `tg://settings/change_number`) are non-standard as well.
