### PR TITLE
Further improvements and fixes for build instructions generator

### DIFF
--- a/build.html
+++ b/build.html
@@ -40,7 +40,7 @@
     body {
       font-family: 'Segoe UI', Arial, Helvetica, sans-serif;
     }
-    :focus:not(:focus-within) {
+    :focus:not(:focus-visible) {
       outline: none;
     }
     input:focus-visible, select:focus-visible, button:focus-visible {
@@ -86,7 +86,7 @@
     a:hover {
       text-decoration: underline;
     }
-    a:focus {
+    a:focus-visible {
       text-decoration: underline 2px; 
       color: var(--color-primary-light);
       outline: none;

--- a/build.html
+++ b/build.html
@@ -9,6 +9,7 @@
       --background: #fafafa;
       --color: black;
       --color-primary: #0088ff;
+      --color-primary-light: #42a7ff;
       --color-code-block: #ebf9ff;
       --color-select-border: rgb(211, 211, 211);
       --color-checkbox-background: rgb(211, 211, 211);
@@ -80,10 +81,15 @@
     a {
       color: var(--color-primary);
       text-decoration-color: transparent;
-      transition: text-decoration-color 200ms;
+      transition: text-decoration 200ms, color 200ms;
     }
     a:hover {
       text-decoration: underline;
+    }
+    a:focus {
+      text-decoration: underline 2px; 
+      color: var(--color-primary-light);
+      outline: none;
     }
     select, button {
       border: 1px solid var(--color-select-border);

--- a/build.html
+++ b/build.html
@@ -3,6 +3,7 @@
 
 <head>
   <title>TDLib build instructions</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <style>
     :root {
       --background: #fafafa;
@@ -70,6 +71,7 @@
       padding: 5px;
       margin-bottom: 0;
       display: block;
+      overflow-x: auto;
     }
     #buildCommands ul {
       list-style: '$ ';

--- a/build.html
+++ b/build.html
@@ -38,6 +38,14 @@
     body {
       font-family: 'Segoe UI', Arial, Helvetica, sans-serif;
     }
+    :focus:not(:focus-within) {
+      outline: none;
+    }
+    input:focus-visible, select:focus-visible, button:focus-visible {
+      box-shadow: 0 0 0 3px var(--color-primary);
+      outline: none;
+    }
+      
     .hide {
       display: none;
     }
@@ -81,17 +89,11 @@
       color: var(--color);
       padding: 5px;
       margin-top: 5px;
-      transition: border 200ms, padding 200ms;
+      box-shadow: 0 0 0 0 var(--color-primary);
+      transition: border 200ms, padding 200ms, box-shadow 200ms;
       border-radius: 999em;
       font-size: 16px;
       cursor: pointer;
-    }
-
-    select:focus, button:focus {
-      outline: none;
-      border-color: var(--color-primary);
-      border-width: 2px;
-      padding: 4px;
     }
 
     label * {
@@ -108,7 +110,7 @@
       width: 20px;
       border-radius: 3px;
       position: relative;
-      transition: background-color 200ms;
+      transition: background-color 200ms, box-shadow 200ms;
     }
     input[type=checkbox]::after {
       content: "";
@@ -141,7 +143,7 @@
       width: 20px;
       border-radius: 100%;
       position: relative;
-      transition: background-color 200ms;
+      transition: background-color 200ms, box-shadow 200ms;
     }
     input[type=radio]::after {
       content: "";

--- a/build.html
+++ b/build.html
@@ -118,6 +118,7 @@
       width: 20px;
       border-radius: 3px;
       position: relative;
+      top: -1px; // Fix alignment
       transition: background-color 200ms, box-shadow 200ms;
     }
     input[type=checkbox]::after {
@@ -151,6 +152,7 @@
       width: 20px;
       border-radius: 100%;
       position: relative;
+      top: -2px; // Fix alignment
       transition: background-color 200ms, box-shadow 200ms;
     }
     input[type=radio]::after {


### PR DESCRIPTION
I made some additional visual (and accessibility) changes in addition to #1689:

## Fixed focus visuals
My previous pull request (#1689) had some problems:
- The focus visuals caused side effects
- The native focus visuals were removed which broke navigation with keyboard (which was reverted)

These changes bring new focus visuals which do not have side-effects and are present in all elements (but some are not triggered by mouse)

## Fixed appearance on mobile devices
The build instructions generator looked terrible on mobile devices:
- Font size was too small and inconsistent
- Command list would overflow if commands were long
Both of them have been fixed.

## Fixed alignment for checkboxes and radio buttons

Checkboxes and radio buttons were 1px / 2px below the perfect alignment with their labels. They have been moved to fix this.

***
Preview: https://mammad900.github.io/td/build.html