### PR TITLE
Add session type field

### DIFF
--- a/td/generate/scheme/td_api.tl
+++ b/td/generate/scheme/td_api.tl
@@ -3281,18 +3281,73 @@ userPrivacySettingAllowFindingByPhoneNumber = UserPrivacySetting;
 accountTtl days:int32 = AccountTtl;
 
 
+//@class SessionType @description Represents the type of a session
+
+//@description This session is running on an Android device
+sessionTypeAndroid = SessionType;
+
+//@description This session is running on a generic Apple device
+sessionTypeApple = SessionType;
+
+//@description This session is running on the Brave browser
+sessionTypeBrave = SessionType;
+
+//@description This session is running on the Chrome browser
+sessionTypeChrome = SessionType;
+
+//@description This session is running on the Edge browser
+sessionTypeEdge = SessionType;
+
+//@description This session is running on the Firefox browser
+sessionTypeFirefox = SessionType;
+
+//@description This session is running on an iPad device
+sessionTypeIpad = SessionType;
+
+//@description This session is running on an iPhone device
+sessionTypeIphone = SessionType;
+
+//@description This session is running on a Linux device
+sessionTypeLinux = SessionType;
+
+//@description This session is running on a Mac device
+sessionTypeMac = SessionType;
+
+//@description This session is running on the Opera browser
+sessionTypeOpera = SessionType;
+
+//@description This session is running on the Safari browser
+sessionTypeSafari = SessionType;
+
+//@description This session is running on an Ubuntu device
+sessionTypeUbuntu = SessionType;
+
+//@description This session is running on an unknown type of device
+sessionTypeUnknown = SessionType;
+
+//@description This session is running on the Vivaldi browser
+sessionTypeVivaldi = SessionType;
+
+//@description This session is running on a Windows device
+sessionTypeWindows = SessionType;
+
+//@description This session is running on a Xbox console
+sessionTypeXbox = SessionType;
+
+
 //@description Contains information about one session in a Telegram application used by the current user. Sessions must be shown to the user in the returned order
 //@id Session identifier @is_current True, if this session is the current session
 //@is_password_pending True, if a password is needed to complete authorization of the session
 //@can_accept_secret_chats True, if incoming secret chats can be accepted by the session
 //@can_accept_calls True, if incoming calls can be accepted by the session
+//@type Session type based on the system and application version, which can be used to display a corresponding icon
 //@api_id Telegram API identifier, as provided by the application @application_name Name of the application, as provided by the application
 //@application_version The version of the application, as provided by the application @is_official_application True, if the application is an official application or uses the api_id of an official application
 //@device_model Model of the device the application has been run or is running on, as provided by the application @platform Operating system the application has been run or is running on, as provided by the application
 //@system_version Version of the operating system the application has been run or is running on, as provided by the application @log_in_date Point in time (Unix timestamp) when the user has logged in
 //@last_active_date Point in time (Unix timestamp) when the session was last used @ip IP address from which the session was created, in human-readable format
 //@country A two-letter country code for the country from which the session was created, based on the IP address @region Region code from which the session was created, based on the IP address
-session id:int64 is_current:Bool is_password_pending:Bool can_accept_secret_chats:Bool can_accept_calls:Bool api_id:int32 application_name:string application_version:string is_official_application:Bool device_model:string platform:string system_version:string log_in_date:int32 last_active_date:int32 ip:string country:string region:string = Session;
+session id:int64 is_current:Bool is_password_pending:Bool can_accept_secret_chats:Bool can_accept_calls:Bool type:SessionType api_id:int32 application_name:string application_version:string is_official_application:Bool device_model:string platform:string system_version:string log_in_date:int32 last_active_date:int32 ip:string country:string region:string = Session;
 
 //@description Contains a list of sessions @sessions List of sessions @inactive_session_ttl_days Number of days of inactivity before sessions will automatically be terminated; 1-366 days
 sessions sessions:vector<session> inactive_session_ttl_days:int32 = Sessions;

--- a/td/telegram/Account.cpp
+++ b/td/telegram/Account.cpp
@@ -34,7 +34,7 @@ static td_api::object_ptr<td_api::SessionType> get_session_type(
     return str.find(substr) != string::npos;
   };
   
-  auto app_name = authorization->app_name_;
+  const string &app_name = authorization->app_name_;
   auto device_model = to_lower(authorization->device_model_);
   auto platform = to_lower(authorization->platform_);
   auto system_version = to_lower(authorization->system_version_);
@@ -43,12 +43,16 @@ static td_api::object_ptr<td_api::SessionType> get_session_type(
     return td_api::make_object<td_api::sessionTypeXbox>();
   }
 
-  bool web = false;
-  string web_name = "Web";
-  if ((auto pos = app_name.find(web_name)) != string::npos) {
-    auto next = app_name.substr(pos + web_name.length(), 1);
-    web = !next.length() || !('a' <= next[0] && next[0] <= 'z');
-  }
+  bool web = [&] {
+    Slice web_name("Web");
+    auto pos = app_name.find(web_name.c_str());
+    if (pos == string::npos) {
+      return false;
+    }
+
+    auto next_character = app_name[pos + web_name.size()];
+    return !('a' <= next_character && next_character <= 'z');
+  }();
 
   if (web) {
     if (contains(device_model, "brave")) {
@@ -68,18 +72,18 @@ static td_api::object_ptr<td_api::SessionType> get_session_type(
     }
   }
 
-  if (contains(platform, "android") || contains(system_version, "android")) {
+  if (begins_with(platform, "android") || contains(system_version, "android")) {
     return td_api::make_object<td_api::sessionTypeAndroid>();
-  } else if (contains(platform, "windows") || contains(system_version, "windows")) {
+  } else if (begins_with(platform, "windows") || contains(system_version, "windows")) {
     return td_api::make_object<td_api::sessionTypeWindows>();
-  } else if (contains(platform, "ubuntu") || contains(system_version, "ubuntu")) {
+  } else if (begins_with(platform, "ubuntu") || contains(system_version, "ubuntu")) {
     return td_api::make_object<td_api::sessionTypeUbuntu>();
-  } else if (contains(platform, "linux") || contains(system_version, "linux")) {
+  } else if (begins_with(platform, "linux") || contains(system_version, "linux")) {
     return td_api::make_object<td_api::sessionTypeLinux>();
   }
 
-  auto ios = contains(platform, "ios") || contains(system_version, "ios");
-  auto macos = contains(platform, "macos") || contains(system_version, "macos");
+  auto ios = begins_with(platform, "ios") || contains(system_version, "ios");
+  auto macos = begins_with(platform, "macos") || contains(system_version, "macos");
   if (ios && contains(device_model, "iphone")) {
     return td_api::make_object<td_api::sessionTypeIphone>();
   } else if (ios && contains(device_model, "ipad")) {

--- a/td/telegram/Account.cpp
+++ b/td/telegram/Account.cpp
@@ -34,7 +34,7 @@ static td_api::object_ptr<td_api::SessionType> get_session_type(
     return str.find(substr) != string::npos;
   };
   
-  auto app_name = to_lower(authorization->app_name_);
+  auto app_name = authorization->app_name_;
   auto device_model = to_lower(authorization->device_model_);
   auto platform = to_lower(authorization->platform_);
   auto system_version = to_lower(authorization->system_version_);
@@ -42,22 +42,29 @@ static td_api::object_ptr<td_api::SessionType> get_session_type(
   if (device_model.find("xbox") != string::npos) {
     return td_api::make_object<td_api::sessionTypeXbox>();
   }
-  
-  if (contains(app_name, "web")) {
-    if (contains(device_model, "chrome")) {
-      return td_api::make_object<td_api::sessionTypeChrome>();
-    } else if (contains(device_model, "brave")) {
+
+  bool web = false;
+  string web_name = "Web";
+  if ((auto pos = app_name.find(web_name)) != string::npos) {
+    auto next = app_name.substr(pos + web_name.length(), 1);
+    web = !next.length() || !('a' <= next[0] && next[0] <= 'z');
+  }
+
+  if (web) {
+    if (contains(device_model, "brave")) {
       return td_api::make_object<td_api::sessionTypeBrave>();
     } else if (contains(device_model, "vivaldi")) {
       return td_api::make_object<td_api::sessionTypeVivaldi>();
-    } else if (contains(device_model, "safari")) {
-      return td_api::make_object<td_api::sessionTypeSafari>();
-    } else if (contains(device_model, "firefox")) {
-      return td_api::make_object<td_api::sessionTypeFirefox>();
-    } else if (contains(device_model, "opera")) {
+    } else if (contains(device_model, "opera") || contains(device_model, "opr")) {
       return td_api::make_object<td_api::sessionTypeOpera>();
     } else if (contains(device_model, "edg")) {
       return td_api::make_object<td_api::sessionTypeEdge>();
+    } else if (contains(device_model, "chrome")) {
+      return td_api::make_object<td_api::sessionTypeChrome>();
+    } else if (contains(device_model, "firefox") || contains(device_model, "fxios")) {
+      return td_api::make_object<td_api::sessionTypeFirefox>();
+    } else if (contains(device_model, "safari")) {
+      return td_api::make_object<td_api::sessionTypeSafari>();
     }
   }
 

--- a/td/telegram/Account.cpp
+++ b/td/telegram/Account.cpp
@@ -29,7 +29,11 @@
 namespace td {
 
 static td_api::object_ptr<td_api::SessionType> get_session_type(
-    tl_object_ptr<telegram_api::authorization> &&authorization) {
+    const tl_object_ptr<telegram_api::authorization> &authorization) {
+  auto contains = [](const string &str, const char *substr) {
+    return str.find(substr) != string::npos;
+  };
+  
   auto app_name = to_lower(authorization->app_name_);
   auto device_model = to_lower(authorization->device_model_);
   auto platform = to_lower(authorization->platform_);
@@ -39,41 +43,41 @@ static td_api::object_ptr<td_api::SessionType> get_session_type(
     return td_api::make_object<td_api::sessionTypeXbox>();
   }
   
-  if (app_name.find("web") != string::npos) {
-    if (device_model.find("chrome") != string::npos) {
+  if (contains(app_name, "web")) {
+    if (contains(device_model, "chrome")) {
       return td_api::make_object<td_api::sessionTypeChrome>();
-    } else if (device_model.find("brave") != string::npos) {
+    } else if (contains(device_model, "brave")) {
       return td_api::make_object<td_api::sessionTypeBrave>();
-    } else if (device_model.find("vivaldi") != string::npos) {
+    } else if (contains(device_model, "vivaldi")) {
       return td_api::make_object<td_api::sessionTypeVivaldi>();
-    } else if (device_model.find("safari") != string::npos) {
+    } else if (contains(device_model, "safari")) {
       return td_api::make_object<td_api::sessionTypeSafari>();
-    } else if (device_model.find("firefox") != string::npos) {
+    } else if (contains(device_model, "firefox")) {
       return td_api::make_object<td_api::sessionTypeFirefox>();
-    } else if (device_model.find("opera") != string::npos) {
+    } else if (contains(device_model, "opera")) {
       return td_api::make_object<td_api::sessionTypeOpera>();
-    } else if (device_model.find("edg") != string::npos) {
+    } else if (contains(device_model, "edg")) {
       return td_api::make_object<td_api::sessionTypeEdge>();
     }
   }
 
-  if ((platform.find("android") != string::npos) || (system_version.find("android") != string::npos)) {
+  if (contains(platform, "android") || contains(system_version, "android")) {
     return td_api::make_object<td_api::sessionTypeAndroid>();
-  } else if ((platform.find("windows") != string::npos) || (system_version.find("windows") != string::npos)) {
+  } else if (contains(platform, "windows") || contains(system_version, "windows")) {
     return td_api::make_object<td_api::sessionTypeWindows>();
-  } else if ((platform.find("ubuntu") != string::npos) || (system_version.find("ubuntu") != string::npos)) {
+  } else if (contains(platform, "ubuntu") || contains(system_version, "ubuntu")) {
     return td_api::make_object<td_api::sessionTypeUbuntu>();
-  } else if ((platform.find("linux") != string::npos) || (system_version.find("linux") != string::npos)) {
+  } else if (contains(platform, "linux") || contains(system_version, "linux")) {
     return td_api::make_object<td_api::sessionTypeLinux>();
   }
 
-  auto ios = (platform.find("ios") != string::npos) || (system_version.find("ios") != string::npos);
-  auto macos = (platform.find("macos") != string::npos) || (system_version.find("macos") != string::npos);
-  if (ios && (device_model.find("iphone") != string::npos)) {
+  auto ios = contains(platform, "ios") || contains(system_version, "ios");
+  auto macos = contains(platform, "macos") || contains(system_version, "macos");
+  if (ios && contains(device_model, "iphone")) {
     return td_api::make_object<td_api::sessionTypeIphone>();
-  } else if (ios && (device_model.find("ipad") != string::npos)) {
+  } else if (ios && contains(device_model, "ipad")) {
     return td_api::make_object<td_api::sessionTypeIpad>();
-  } else if (macos && (device_model.find("mac") != string::npos)) {
+  } else if (macos && contains(device_model, "mac")) {
     return td_api::make_object<td_api::sessionTypeMac>();
   } else if (ios || macos) {
     return td_api::make_object<td_api::sessionTypeApple>();
@@ -88,7 +92,7 @@ static td_api::object_ptr<td_api::session> convert_authorization_object(
   return td_api::make_object<td_api::session>(
       authorization->hash_, authorization->current_, authorization->password_pending_,
       !authorization->encrypted_requests_disabled_, !authorization->call_requests_disabled_,
-      get_session_type(std::move(authorization)), authorization->api_id_, authorization->app_name_,
+      get_session_type(authorization), authorization->api_id_, authorization->app_name_,
       authorization->app_version_, authorization->official_app_, authorization->device_model_,
       authorization->platform_, authorization->system_version_, authorization->date_created_,
       authorization->date_active_, authorization->ip_, authorization->country_, authorization->region_);


### PR DESCRIPTION
This pull request adds a new `type` field to the `session` class, which can be used by graphical clients to display a corresponding icon.

*Currently, apps are supposed to parse session parameters themselves to detect its type, which can lead to inconsistencies.*

I used the same conditions as the official [iOS](https://github.com/TelegramMessenger/Telegram-iOS/blob/f95cfbdc42bee2b4ee92750ca2bda0e85d68e942/submodules/SettingsUI/Sources/Privacy%20and%20Security/Recent%20Sessions/ItemListRecentSessionItem.swift#L113) and [macOS](https://github.com/overtake/TelegramSwift/blob/13d62c1c03df7dea70bad0f395fb68115f5a0b43/Telegram-Mac/RecentSessionsController.swift#L19) apps, and [Unigram](https://github.com/UnigramDev/Unigram/blob/4870c5ef42d757c93297da2fbafa29fc04c97f38/Unigram/Unigram/Controls/Cells/SessionCell.xaml.cs#L42), with some improvements.
