### PR TITLE
Disable UI interaction requirement for example/ios openssl

### DIFF
--- a/example/ios/Python-Apple-support.patch
+++ b/example/ios/Python-Apple-support.patch
@@ -67,8 +67,15 @@ index 695be54..4efe5e5 100644
  # override machine types for arm64
  MACHINE_DETAILED-arm64=aarch64
  MACHINE_SIMPLE-arm64=arm
-@@ -194,9 +211,11 @@ endif
- 
+@@ -192,11 +209,18 @@ ifeq ($$(findstring iphone,$$(SDK-$1)),)
+ 	LC_ALL=C sed -ie 's/-D_REENTRANT:iOS/-D_REENTRANT:$2/' $$(OPENSSL_DIR-$1)/Configure
+ endif
+
++ifeq (,$(filter $1,OpenSSL-iOS-simulator OpenSSL-watchOS-simulator))
++	# Patch OpenSSL rehash, since it requres a UI interaction
++	cd $$(OPENSSL_DIR-$1) && git apply ../../../../openssl-disable-rehash.patch
++endif
++
  	# Configure the build
  ifeq ($2,macOS)
 +	# Patch openssl-darwin-arm64

--- a/example/ios/openssl-disable-rehash.patch
+++ b/example/ios/openssl-disable-rehash.patch
@@ -1,0 +1,11 @@
+--- Makefile.org	2019-12-20 14:02:41.000000000 +0100
++++ Makefile.org	2022-10-01 13:23:13.000000000 +0100
+@@ -460,7 +460,7 @@ rehash.time: certs apps
+ 		[ -x "apps/openssl.exe" ] && OPENSSL="apps/openssl.exe" || :; \
+ 		OPENSSL_DEBUG_MEMORY=on; \
+ 		export OPENSSL OPENSSL_DEBUG_MEMORY; \
+-		$(PERL) tools/c_rehash certs/demo) && \
++		echo 'certs/demo rehash skipped') && \
+ 		touch rehash.time; \
+ 	else :; fi
+ 


### PR DESCRIPTION
## Issue
Starting [August](https://github.com/Swiftgram/TDLibFramework/actions/runs/2805040753) i've been experiencing a big timeouts building OpenSSL for iOS and watchOS simulators.
<img width="208" alt="image" src="https://user-images.githubusercontent.com/24507532/193410939-38cea644-be4c-4bf3-9b81-6fb7c18ba7aa.png">

I was able to reproduce it locally and turned out that (for some unknown reason) macOS shows an alert while invoking openSSL `tools/c_rehash` before binary tests.
![image](https://user-images.githubusercontent.com/24507532/193411045-ac12ba83-e721-4311-a64e-4732fa16005c.png)

macOS console says there's an error `ASP: Security policy would not allow process: 56497`

## Solution
I've not found any ways to successfully patch the binary for running (with xattr, chmod and etc).

This PR creates a patch for OpenSSL's Makefile that will simply disable this rehash process for `OpenSSL-iOS-simulator` and `OpenSSL-watchOS-simulator` targets.

This should not affect the stability of openSSL itself and affect any other targets.

