### PR TITLE
Fix MinGW threading compilation error

### DIFF
--- a/tdutils/td/utils/port/detail/ThreadStl.h
+++ b/tdutils/td/utils/port/detail/ThreadStl.h
@@ -81,7 +81,11 @@ class ThreadStl {
 
   id get_id() noexcept {
 #if TD_WINDOWS
+#ifdef __MINGW32__
+    return GetThreadId(reinterpret_cast<HANDLE>(thread_.native_handle()));
+#else
     return GetThreadId(thread_.native_handle());
+#endif
 #else
     return thread_.get_id();
 #endif


### PR DESCRIPTION
This PR fixes two compilation error in MinGW-w64 under MSYS:

1. **Thread compilation error: invalid conversion**
   Same problem has been found here: https://github.com/boostorg/fiber/pull/281. In TDLib it happens in `tdutils/td/utils/port/detail/ThreadStl.h` and adding `reinterpret_cast<HANDLE>` fixes it.
2. **cc1plus.exe: out of memory**
   This happens only in 32-bit MinGW build. `td/telegram/MessagesManager.cpp` gives an out of memory error. There is an [old compiler bug in GCC](https://sourceforge.net/p/mingw-w64/mailman/message/33182613/) which either wasn't fixed or reappeared again. Adding `-ftrack-macro-expansion=0` to compiler flags solves the problem.
   Moved to #2212 by request.