### PR TITLE
Fix MinGW (32-bit) out of memory error

### DIFF
--- a/CMake/TdSetUpCompiler.cmake
+++ b/CMake/TdSetUpCompiler.cmake
@@ -155,6 +155,10 @@ function(td_set_up_compiler)
     add_cxx_compiler_flag("-Wno-return-stack-address")
   endif()
 
+  if (MINGW)
+    add_cxx_compiler_flag("-ftrack-macro-expansion=0")
+  endif()
+
   #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -isystem /usr/include/c++/v1")
   #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
   #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=thread")


### PR DESCRIPTION
Moved from #2210 with changes suggested in its comments.

This PR fixes `cc1plus.exe: out of memory` error in 32-bit MinGW build. td/telegram/MessagesManager.cpp gives an out of memory error. There is an [old compiler bug in GCC](https://sourceforge.net/p/mingw-w64/mailman/message/33182613/) which either wasn't fixed or reappeared again. Adding `-ftrack-macro-expansion=0` to compiler flags solves the problem.