### PR TITLE
Fix a type on viewMessages method documentation.

### DIFF
--- a/td/generate/scheme/td_api.tl
+++ b/td/generate/scheme/td_api.tl
@@ -6663,8 +6663,8 @@ closeChat chat_id:int53 = Ok;
 //-Many useful activities depend on whether the messages are currently being viewed or not (e.g., marking messages as read, incrementing a view counter, updating a view counter, removing deleted messages in supergroups and channels)
 //@chat_id Chat identifier
 //@message_ids The identifiers of the messages being viewed
-//@source Source of the message view
-//@force_read Pass true to mark as read the specified messages even the chat is closed; pass null to guess the source based on chat open state
+//@source Source of the message view; pass null to guess the source based on chat open state
+//@force_read Pass true to mark as read the specified messages even the chat is closed
 viewMessages chat_id:int53 message_ids:vector<int53> source:MessageSource force_read:Bool = Ok;
 
 //@description Informs TDLib that the message content has been opened (e.g., the user has opened a photo, video, document, location or venue, or has listened to an audio file or voice note message).


### PR DESCRIPTION
The `source` argument should be marked as maybe null, not the `force_reply` argument.