### PR TITLE
waitsForConnectivity, configurations for URLSession

### DIFF
--- a/tdnet/td/net/DarwinHttp.mm
+++ b/tdnet/td/net/DarwinHttp.mm
@@ -19,6 +19,7 @@ NSURLSession *getSession() {
   static NSURLSession *urlSession = [] {
     auto configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
     configuration.networkServiceType = NSURLNetworkServiceTypeResponsiveData;
+    configuration.timeoutIntervalForResource = 90;
     configuration.waitsForConnectivity = true;
     return [NSURLSession sessionWithConfiguration:configuration];
   }();


### PR DESCRIPTION
Attempts to fix a part of #2499, comment:
> Here's the interesting thing that I observed today, even after re-enabling IPv4 (and at the point where IPv4 websites are already usable in Safari), the errors still keep streaming in, and attempting to open a chat (or do anything basically, that being an example), just didn't work.

I made this minor change, observation seems to suggest that this at least recovers after connection is loss, rather than just not working at all after connection loss. (It does not change any IPv6 behaviour mentioned in the same issue)