### PR TITLE
Strongly typed API for asynchronous TDLib method execution in Java interface

### DIFF
--- a/example/java/org/drinkless/tdlib/Client.java
+++ b/example/java/org/drinkless/tdlib/Client.java
@@ -145,8 +145,7 @@ public final class Client {
      *
      * @param query         Object representing a query to the TDLib.
      * @param resultHandler Result handler with onResult method which will be called with result
-     *                      of the query or with TdApi.Error as parameter. If it is null, then
-     *                      defaultExceptionHandler will be called.
+     *                      of the query or with TdApi.Error as parameter.
      * @throws NullPointerException if query is null.
      */
     public void send(TdApi.Function<?> query, ResultHandler resultHandler) {

--- a/example/java/org/drinkless/tdlib/Client.java
+++ b/example/java/org/drinkless/tdlib/Client.java
@@ -122,7 +122,7 @@ public final class Client {
      *                         defaultExceptionHandler will be called.
      * @throws NullPointerException if query is null.
      */
-    public void send(TdApi.Function query, ResultHandler resultHandler, ExceptionHandler exceptionHandler) {
+    public void send(TdApi.Function<?> query, ResultHandler resultHandler, ExceptionHandler exceptionHandler) {
         long queryId = currentQueryId.incrementAndGet();
         if (resultHandler != null) {
             handlers.put(queryId, new Handler(resultHandler, exceptionHandler));
@@ -139,7 +139,7 @@ public final class Client {
      *                      defaultExceptionHandler will be called.
      * @throws NullPointerException if query is null.
      */
-    public void send(TdApi.Function query, ResultHandler resultHandler) {
+    public void send(TdApi.Function<?> query, ResultHandler resultHandler) {
         send(query, resultHandler, null);
     }
 
@@ -315,11 +315,11 @@ public final class Client {
 
     private static native int createNativeClient();
 
-    private static native void nativeClientSend(int nativeClientId, long eventId, TdApi.Function function);
+    private static native void nativeClientSend(int nativeClientId, long eventId, TdApi.Function<?> function);
 
     private static native int nativeClientReceive(int[] clientIds, long[] eventIds, TdApi.Object[] events, double timeout);
 
-    private static native TdApi.Object nativeClientExecute(TdApi.Function function);
+    private static native TdApi.Object nativeClientExecute(TdApi.Function<?> function);
 
     private static native void nativeClientSetLogMessageHandler(int maxVerbosityLevel, LogMessageHandler logMessageHandler);
 }

--- a/example/java/org/drinkless/tdlib/Client.java
+++ b/example/java/org/drinkless/tdlib/Client.java
@@ -131,6 +131,16 @@ public final class Client {
     }
 
     /**
+     * Sends a request to the TDLib with an empty ResultHandler and ExceptionHandler.
+     *
+     * @param query Object representing a query to the TDLib.
+     * @throws NullPointerException if query is null.
+     */
+    public void send(TdApi.Function<?> query) {
+        send(query, (ResultHandler) null, null);
+    }
+
+    /**
      * Sends a request to the TDLib with an empty ExceptionHandler.
      *
      * @param query         Object representing a query to the TDLib.

--- a/example/java/org/drinkless/tdlib/Client.java
+++ b/example/java/org/drinkless/tdlib/Client.java
@@ -52,6 +52,9 @@ public final class Client {
          * @return Handler converted to {@link ResultHandler}
          */
         static <T extends TdApi.Object> ResultHandler toResultHandler(TypedResultHandler<T> handler) {
+            if (handler == null) {
+                return null;
+            }
             return result -> {
                 if (result.getConstructor() == TdApi.Error.CONSTRUCTOR) {
                     handler.onResult(null, (TdApi.Error) result);


### PR DESCRIPTION
This PR includes:
* Strongly typed `Client.send` methods, callback parameter type of which is based on the return type declared in `TdApi.Function` child class, which allow compile-time protection against return type changes, avoiding casts on caller side, etc. Weakly typed `send` methods remain unchanged for compatibility purposes.
* `Client.send` method without any callbacks. The only reason for it is because `client.send(function, null)` will now cause compile error
* Warning fix for raw parametrized use of `TdApi.Function`
* Small documentation fix in `Client.java`

This allows using the following pattern when executing methods in Java:
```
client.send(new TdApi.SpecificReturnTypeFunction(), (typedResult, error) -> {
  if (error != null) {
    // handle error
  } else {
    // work with typedResult without any casting
  }
});
```