### PR TITLE
Fix DialogActionManager::send_dialog_action in secret chats

### DIFF
--- a/td/telegram/DialogActionManager.cpp
+++ b/td/telegram/DialogActionManager.cpp
@@ -289,6 +289,14 @@ void DialogActionManager::send_dialog_action(DialogId dialog_id, MessageId top_t
   if (!td_->dialog_manager_->have_dialog_force(dialog_id, "send_dialog_action")) {
     return promise.set_error(Status::Error(400, "Chat not found"));
   }
+
+  if (dialog_id.get_type() == DialogType::SecretChat) {
+    send_closure(G()->secret_chats_manager(), &SecretChatsManager::send_message_action, dialog_id.get_secret_chat_id(),
+                 action.get_secret_input_send_message_action());
+    promise.set_value(Unit());
+    return;
+  }
+
   if (top_thread_message_id != MessageId() &&
       (!top_thread_message_id.is_valid() || !top_thread_message_id.is_server())) {
     return promise.set_error(Status::Error(400, "Invalid message thread specified"));
@@ -319,13 +327,6 @@ void DialogActionManager::send_dialog_action(DialogId dialog_id, MessageId top_t
 
     input_peer = td_->dialog_manager_->get_input_peer(dialog_id, AccessRights::Write);
     CHECK(input_peer != nullptr);
-  }
-
-  if (dialog_id.get_type() == DialogType::SecretChat) {
-    send_closure(G()->secret_chats_manager(), &SecretChatsManager::send_message_action, dialog_id.get_secret_chat_id(),
-                 action.get_secret_input_send_message_action());
-    promise.set_value(Unit());
-    return;
   }
 
   auto new_query_ref =


### PR DESCRIPTION
The [code recently introduced in `DialogActionManager::send_dialog_action`](https://github.com/tdlib/td/commit/b684039566057385228e8b6a06ab6afcc05277f6#diff-bce63a6e456e5472a3ffac1f725c5f2a02285d243c50001366b3dcc79f472888R292-R313) makes the assumption that, since we'd either have early returned or `DialogManager::have_input_peer` would return true; that the else block of the conditional, which intended to set `input_peer`, should have done so successfully.

However, [`DialogManager::have_input_peer` will return true for secret chats when `contacts_manager->have_input_encrypted_peer`](https://github.com/tdlib/td/blob/4bafdc2b7129694c5b1b36eb7109043f92f13a0a/td/telegram/DialogManager.cpp#L632-L635)
And [`DialogManager::get_input_peer` will return a `nullptr` for secret chats](https://github.com/tdlib/td/blob/4bafdc2b7129694c5b1b36eb7109043f92f13a0a/td/telegram/DialogManager.cpp#L522-L523) by design
(I believe this is because they operate using structures that are currently incompatible)

There is [a block in `DialogActionManager::send_dialog_action` meant for handling Secret Chats](https://github.com/tdlib/td/blob/4bafdc2b7129694c5b1b36eb7109043f92f13a0a/td/telegram/DialogActionManager.cpp#L324-L329) that will return early and avoid using the locally scoped data, like `input_peer`, being prepared at the beginning of the function.

This should fix the root of a crash that happens when typing in or sending messages (like ones with attachments) to secret chats on: Telegram X 0.26.4.1678-arm64-v8a (99b10675)
TDLib: 1.8.23 (tdlib/td@4bafdc2)

My proposed change moves the Secret Chat block up to before anything is done to prepare locally scoped data objects that aren't used in the case of secret chats.
Note that it doesn't include the return when `is_dialog_action_unneeded`, and I do not have the familiarity to know if that is still useful to check first.
If this is the case, it may be better to simply move the `CHECK(input_peer != nullptr);` to after the block meant to handle secret chats, because it is after point where we will access that pointer, and would therefore want it set.