### PR TITLE
Moved the use of methods marked constexpr since c++20 to forward declared types

### DIFF
--- a/tdutils/td/utils/JsonBuilder.cpp
+++ b/tdutils/td/utils/JsonBuilder.cpp
@@ -542,6 +542,13 @@ Slice JsonValue::get_type_name(Type type) {
   }
 }
 
+JsonObject::JsonObject(vector<std::pair<Slice, JsonValue>> &&field_values) : field_values_(std::move(field_values)) {
+}
+
+size_t JsonObject::field_count() const {
+  return field_values_.size();
+}
+
 JsonValue JsonObject::extract_field(Slice name) {
   for (auto &field_value : field_values_) {
     if (field_value.first == name) {

--- a/tdutils/td/utils/JsonBuilder.h
+++ b/tdutils/td/utils/JsonBuilder.h
@@ -464,8 +464,7 @@ class JsonObject {
 
   JsonObject() = default;
 
-  explicit JsonObject(vector<std::pair<Slice, JsonValue>> &&field_values) : field_values_(std::move(field_values)) {
-  }
+  explicit JsonObject(vector<std::pair<Slice, JsonValue>> &&field_values);
 
   JsonObject(const JsonObject &) = delete;
   JsonObject &operator=(const JsonObject &) = delete;
@@ -473,9 +472,7 @@ class JsonObject {
   JsonObject &operator=(JsonObject &&) = default;
   ~JsonObject() = default;
 
-  size_t field_count() const {
-    return field_values_.size();
-  }
+  size_t field_count() const;
 
   JsonValue extract_field(Slice name);
 


### PR DESCRIPTION
When I tried to build using clang 16 and c++20, I got a compilation error like this:
```
In file included from /home/mikhnenko/libs/tdlib/td/telegram/ClientJson.cpp:7:
In file included from /home/mikhnenko/libs/tdlib/td/telegram/ClientJson.h:9:
In file included from /home/mikhnenko/libs/tdlib/td/telegram/Client.h:11:
In file included from /home/mikhnenko/libs/tdlib/td/generate/auto/td/telegram/td_api.h:3:
In file included from /home/mikhnenko/libs/tdlib/td/tl/TlObject.h:16:
In file included from /home/mikhnenko/libs/cxxsupp/libcxx/include/string:574:
In file included from /home/mikhnenko/libs/cxxsupp/libcxx/include/__functional/hash.h:24:
/home/mikhnenko/libs/cxxsupp/libcxx/include/__utility/pair.h:90:9: error: field has incomplete type 'td::JsonValue'
    _T2 second;
        ^
/home/mikhnenko/libs/cxxsupp/libcxx/include/vector:959:62: note: in instantiation of template class 'std::pair<td::Slice, td::JsonValue>' requested here
        __alloc_traits::destroy(__alloc(), std::__to_address(--__soon_to_be_end));
                                                             ^
/home/mikhnenko/libs/cxxsupp/libcxx/include/vector:953:29: note: in instantiation of member function 'std::vector<std::pair<td::Slice, td::JsonValue>>::__base_destruct_at_end' requested here
  void __clear() _NOEXCEPT {__base_destruct_at_end(this->__begin_);}
                            ^
/home/mikhnenko/libs/cxxsupp/libcxx/include/vector:495:20: note: in instantiation of member function 'std::vector<std::pair<td::Slice, td::JsonValue>>::__clear' requested here
            __vec_.__clear();
                   ^
/home/mikhnenko/libs/cxxsupp/libcxx/include/vector:506:67: note: in instantiation of member function 'std::vector<std::pair<td::Slice, td::JsonValue>>::__destroy_vector::operator()' requested here
  _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI ~vector() { __destroy_vector(*this)(); }
                                                                  ^
/home/mikhnenko/libs/tdlib/tdutils/td/utils/JsonBuilder.h:467:12: note: in instantiation of member function 'std::vector<std::pair<td::Slice, td::JsonValue>>::~vector' requested here
  explicit JsonObject(vector<std::pair<Slice, JsonValue>> &&field_values) : field_values_(std::move(field_values)) {
           ^
/home/mikhnenko/libs/tdlib/tdutils/td/utils/JsonBuilder.h:453:7: note: forward declaration of 'td::JsonValue'
class JsonValue;
```

I think it is connected with constexpr vector constructor. So I move implementation to .cpp file.