### PR TITLE
td_api::messageSendOptions#random_id

### DIFF
--- a/td/generate/scheme/td_api.tl
+++ b/td/generate/scheme/td_api.tl
@@ -3486,7 +3486,7 @@ messageSelfDestructTypeImmediately = MessageSelfDestructType;
 //@effect_id Identifier of the effect to apply to the message; applicable only to sendMessage and sendMessageAlbum in private chats
 //@sending_id Non-persistent identifier, which will be returned back in messageSendingStatePending object and can be used to match sent messages and corresponding updateNewMessage updates
 //@only_preview Pass true to get a fake message instead of actually sending them
-messageSendOptions disable_notification:Bool from_background:Bool protect_content:Bool update_order_of_installed_sticker_sets:Bool scheduling_state:MessageSchedulingState effect_id:int64 sending_id:int32 only_preview:Bool = MessageSendOptions;
+messageSendOptions random_id:int32 disable_notification:Bool from_background:Bool protect_content:Bool update_order_of_installed_sticker_sets:Bool scheduling_state:MessageSchedulingState effect_id:int64 sending_id:int32 only_preview:Bool = MessageSendOptions;
 
 //@description Options to be used when a message content is copied without reference to the original sender. Service messages, messages with messageInvoice, messagePremiumGiveaway, or messagePremiumGiveawayWinners content can't be copied
 //@send_copy True, if content of the message needs to be copied without reference to the original sender. Always true if the message is forwarded to a secret chat or is local

--- a/td/telegram/MessagesManager.cpp
+++ b/td/telegram/MessagesManager.cpp
@@ -23095,7 +23095,7 @@ MessagesManager::Message *MessagesManager::get_message_to_send(
                                         real_forward_from_dialog_id, is_copy, send_as_dialog_id);
 
   auto message_id = message->message_id;
-  message->random_id = generate_new_random_id(d);
+  message->random_id = options.random_id != 0 ? options.random_id : generate_new_random_id(d);
 
   bool need_update = false;
   CHECK(td_->dialog_manager_->have_input_peer(d->dialog_id, true, AccessRights::Read));
@@ -23730,6 +23730,7 @@ Result<MessagesManager::MessageSendOptions> MessagesManager::process_message_sen
     return std::move(result);
   }
 
+  result.random_id = options->random_id_;
   result.disable_notification = options->disable_notification_;
   result.from_background = options->from_background_;
   if (allow_update_stickersets_order) {
@@ -26529,7 +26530,7 @@ Result<td_api::object_ptr<td_api::messages>> MessagesManager::send_quick_reply_s
   auto *d = get_dialog(dialog_id);
   CHECK(d != nullptr);
 
-  MessageSendOptions message_send_options(false, false, false, false, false, 0, sending_id, 0);
+  MessageSendOptions message_send_options(0, false, false, false, false, false, 0, sending_id, 0);
   FlatHashMap<MessageId, MessageId, MessageIdHash> original_message_id_to_new_message_id;
   vector<td_api::object_ptr<td_api::message>> result;
   vector<Message *> sent_messages;
@@ -26739,7 +26740,7 @@ Result<vector<MessageId>> MessagesManager::resend_messages(DialogId dialog_id, v
     } else if (need_drop_reply) {
       message->input_reply_to = {};
     }
-    MessageSendOptions options(message->disable_notification, message->from_background,
+    MessageSendOptions options(0, message->disable_notification, message->from_background,
                                message->update_stickersets_order, message->noforwards, false,
                                get_message_schedule_date(message.get()), message->sending_id, message->effect_id);
     Message *m = get_message_to_send(d, message->top_thread_message_id, std::move(message->input_reply_to), options,

--- a/td/telegram/MessagesManager.h
+++ b/td/telegram/MessagesManager.h
@@ -1478,6 +1478,7 @@ class MessagesManager final : public Actor {
   };
 
   struct MessageSendOptions {
+    int32 random_id = 0;
     bool disable_notification = false;
     bool from_background = false;
     bool update_stickersets_order = false;
@@ -1488,9 +1489,10 @@ class MessagesManager final : public Actor {
     int64 effect_id = 0;
 
     MessageSendOptions() = default;
-    MessageSendOptions(bool disable_notification, bool from_background, bool update_stickersets_order,
+    MessageSendOptions(int32 random_id, bool disable_notification, bool from_background, bool update_stickersets_order,
                        bool protect_content, bool only_preview, int32 schedule_date, int32 sending_id, int64 effect_id)
-        : disable_notification(disable_notification)
+        : random_id(random_id)
+        , disable_notification(disable_notification)
         , from_background(from_background)
         , update_stickersets_order(update_stickersets_order)
         , protect_content(protect_content)

--- a/td/telegram/cli.cpp
+++ b/td/telegram/cli.cpp
@@ -2410,7 +2410,7 @@ class CliClient final : public Actor {
     }
     auto id = send_request(td_api::make_object<td_api::sendMessage>(
         chat_id, message_thread_id_, get_input_message_reply_to(),
-        td_api::make_object<td_api::messageSendOptions>(disable_notification, from_background, false, false,
+        td_api::make_object<td_api::messageSendOptions>(0, disable_notification, from_background, false, false,
                                                         as_message_scheduling_state(schedule_date_), message_effect_id_,
                                                         Random::fast(1, 1000), only_preview_),
         nullptr, std::move(input_message_content)));
@@ -2420,7 +2420,7 @@ class CliClient final : public Actor {
   }
 
   td_api::object_ptr<td_api::messageSendOptions> default_message_send_options() const {
-    return td_api::make_object<td_api::messageSendOptions>(false, false, false, true,
+    return td_api::make_object<td_api::messageSendOptions>(0, false, false, false, true,
                                                            as_message_scheduling_state(schedule_date_),
                                                            message_effect_id_, Random::fast(1, 1000), only_preview_);
   }


### PR DESCRIPTION
Following-up https://github.com/tdlib/telegram-bot-api/issues/482#issuecomment-2165067053
If I've understood correctly, I will have to use the parameter in that repository like this and add some docs for it.

```
diff --git a/telegram-bot-api/Client.cpp b/telegram-bot-api/Client.cpp
index 142dc26..1b363d4 100644
--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -7727,9 +7727,9 @@ td::Result<td_api::object_ptr<td_api::InputMessageContent>> Client::get_input_me
   return nullptr;
 }
 
-td_api::object_ptr<td_api::messageSendOptions> Client::get_message_send_options(bool disable_notification,
+td_api::object_ptr<td_api::messageSendOptions> Client::get_message_send_options(int32 random_id, bool disable_notification,
                                                                                 bool protect_content, int64 effect_id) {
-  return make_object<td_api::messageSendOptions>(disable_notification, false, protect_content, false, nullptr,
+  return make_object<td_api::messageSendOptions>(random_id, disable_notification, false, protect_content, false, nullptr,
                                                  effect_id, 0, false);
 }
 
@@ -10074,7 +10074,7 @@ td::Status Client::process_copy_messages_query(PromisedQueryPtr &query) {
 
           send_request(make_object<td_api::forwardMessages>(
                            chat_id, message_thread_id, from_chat_id, std::move(message_ids),
-                           get_message_send_options(disable_notification, protect_content, 0), true, remove_caption),
+                           get_message_send_options(0, disable_notification, protect_content, 0), true, remove_caption),
                        td::make_unique<TdOnForwardMessagesCallback>(this, chat_id, message_count, std::move(query)));
         });
   };
@@ -10128,7 +10128,7 @@ td::Status Client::process_forward_messages_query(PromisedQueryPtr &query) {
 
           send_request(make_object<td_api::forwardMessages>(
                            chat_id, message_thread_id, from_chat_id, std::move(message_ids),
-                           get_message_send_options(disable_notification, protect_content, 0), false, false),
+                           get_message_send_options(0, disable_notification, protect_content, 0), false, false),
                        td::make_unique<TdOnForwardMessagesCallback>(this, chat_id, message_count, std::move(query)));
         });
   };
@@ -10190,7 +10190,7 @@ td::Status Client::process_send_media_group_query(PromisedQueryPtr &query) {
 
           send_request(make_object<td_api::sendMessageAlbum>(
                            chat_id, message_thread_id, get_input_message_reply_to(std::move(reply_parameters)),
-                           get_message_send_options(disable_notification, protect_content, effect_id),
+                           get_message_send_options(0, disable_notification, protect_content, effect_id),
                            std::move(input_message_contents)),
                        td::make_unique<TdOnSendMessageAlbumCallback>(this, chat_id, message_count, std::move(query)));
         };
@@ -11994,6 +11994,7 @@ void Client::delete_last_send_message_time(td::int64 file_size, double max_delay
 
 void Client::do_send_message(object_ptr<td_api::InputMessageContent> input_message_content, PromisedQueryPtr query,
                              bool force) {
+  auto random_id = td::to_integer<int32>(query->arg("random_id"));
   auto chat_id = query->arg("chat_id");
   auto message_thread_id = get_message_id(query.get(), "message_thread_id");
   auto business_connection_id = query->arg("business_connection_id");
@@ -12051,7 +12052,7 @@ void Client::do_send_message(object_ptr<td_api::InputMessageContent> input_messa
 
           send_request(make_object<td_api::sendMessage>(
                            chat_id, message_thread_id, get_input_message_reply_to(std::move(reply_parameters)),
-                           get_message_send_options(disable_notification, protect_content, effect_id),
+                           get_message_send_options(random_id, disable_notification, protect_content, effect_id),
                            std::move(reply_markup), std::move(input_message_content)),
                        td::make_unique<TdOnSendMessageCallback>(this, chat_id, std::move(query)));
         };
diff --git a/telegram-bot-api/Client.h b/telegram-bot-api/Client.h
index 4e0bc74..791d621 100644
--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -560,7 +560,7 @@ class Client final : public WebhookActor::Callback {
 
   td::Result<object_ptr<td_api::inputMessageInvoice>> get_input_message_invoice(const Query *query) const;
 
-  static object_ptr<td_api::messageSendOptions> get_message_send_options(bool disable_notification,
+  static object_ptr<td_api::messageSendOptions> get_message_send_options(int32 random_id, bool disable_notification,
                                                                          bool protect_content, int64 effect_id);
 
   static td::Result<td::vector<object_ptr<td_api::formattedText>>> get_poll_options(const Query *query);
```