### PR TITLE
Allow opting out of test building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ if (TD_ENABLE_DOTNET AND (CMAKE_VERSION VERSION_LESS "3.1.0"))
   message(FATAL_ERROR "CMake 3.1.0 or higher is required. You are running version ${CMAKE_VERSION}.")
 endif()
 
-enable_testing()
+include(CTest)
 
 if (POLICY CMP0069)
   option(TD_ENABLE_LTO "Use \"ON\" to enable Link Time Optimization.")
@@ -227,7 +227,9 @@ add_subdirectory(sqlite)
 
 add_subdirectory(tddb)
 
-add_subdirectory(test)
+if (BUILD_TESTING)
+  add_subdirectory(test)
+endif()
 
 if (NOT CMAKE_CROSSCOMPILING)
   add_subdirectory(benchmark)


### PR DESCRIPTION
https://cmake.org/cmake/help/v3.0/module/CTest.html explains that including the `CTest` module and using the created `BUILD_TESTING` option allows users to opt out of creating tests when testing isn't desired.

This is what I would usually submit to projects, where using it via `add_subdirectory()` from another project is not a consideration. Since `BUILD_TESTING` is a cache variable, is this a problem again? So maybe just

```cmake
if (BUILD_TESTING)
  enable_testing()
  add_subdirectory(test)
endif()
```

…without including `CTest` (since that's what defines the `option()`)? Though this would default to the tests not being built, while using the `option()` would [preserve current behaviour](https://github.com/Kitware/CMake/blob/v3.0.2/Modules/CTest.cmake#L80)…