### PR TITLE
Improve UWP build script

### DIFF
--- a/example/uwp/SDKManifest.xml
+++ b/example/uwp/SDKManifest.xml
@@ -7,6 +7,6 @@
     AppliesTo="WindowsAppContainer"
     DependsOn="Microsoft.VCLibs, version=14.0"
     SupportsMultipleVersions="Error"
-    SupportedArchitectures="x86;x64;ARM">
+    SupportedArchitectures="x86;x64;ARM;ARM64">
   <File Reference="Telegram.Td.winmd" Implementation="Telegram.Td.dll" />
 </FileList>


### PR DESCRIPTION
This uses an array for `-arch` parameter that's validated by PowerShell directly.
Allows to specify multiple architectures at once without having to build either all of them or just one.