### PR TITLE
Fix unreachable inner if condition

### DIFF
--- a/td/telegram/cli.cpp
+++ b/td/telegram/cli.cpp
@@ -3466,9 +3466,9 @@ class CliClient final : public Actor {
       get_args(args, language_code, key, value);
       td_api::object_ptr<td_api::languagePackString> str =
           td_api::make_object<td_api::languagePackString>(key, nullptr);
-      if (op == "sclsv") {
+      if (op == "sclpsv") {
         str->value_ = td_api::make_object<td_api::languagePackStringValueOrdinary>(value);
-      } else if (op == "sclsp") {
+      } else if (op == "sclpsp") {
         str->value_ = td_api::make_object<td_api::languagePackStringValuePluralized>(value, string("One\0One", 7),
                                                                                      "Two", "Few", "Many", "Other");
       } else {


### PR DESCRIPTION
The outer condition checks if op is one of `"sclpsv", "sclpsp" or "sclpsd"` where the inner condition checks against `"sclsv" and "sclsp"`.

Enums will be a great choice here, as the code grows you have to keep track of the exact string option. However,  you may also consider using a static analysis tool such as [**Cppcheck**](https://github.com/danmar/cppcheck) to detect issues like this. You might also integrate it into a CI workflow for automated checks.

Have a great day!