### PR TITLE
Fix iOS build with cmake v4

### DIFF
--- a/example/ios/build.sh
+++ b/example/ios/build.sh
@@ -55,7 +55,7 @@ do
       fi
 
       echo "iOS platform = ${ios_platform}"
-      other_options="-DIOS_PLATFORM=${ios_platform} -DCMAKE_TOOLCHAIN_FILE=${td_path}/CMake/iOS.cmake"
+      other_options="-DIOS_PLATFORM=${ios_platform} -DCMAKE_TOOLCHAIN_FILE=${td_path}/CMake/iOS.cmake -DCMAKE_MAKE_PROGRAM=make"
     fi
 
     set_cmake_options $platform


### PR DESCRIPTION
Cmake got updated recently and now `brew`'s default version is v4. TDLib Apple builds fail if `CMAKE_MAKE_PROGRAM` is not set. This PR explicitly sets this value. 
```
CMake Error: CMake was unable to find a build program corresponding to "Unix Makefiles".  CMAKE_MAKE_PROGRAM is not set.  You probably need to select a different build tool.
```

`macOS` buids are not affected. Make sure to run any other Apple target when you'll be testing this.

My guess it's due to using `CMAKE_FIND_ROOT_PATH_MODE_PROGRAM ONLY` in [CMake/iOS.cmake](https://github.com/tdlib/td/blob/086b549dbbc16c09bbf1b03ad8c87848f37b88a6/CMake/iOS.cmake#L256). I [once pointed out](https://t.me/tdlibchat/108339) it's a reason why `find_program(CCACHE_FOUND ccache)` doesn't work for iOS builds.
Perhaps we should try to use `find_host_package` on a global basis or revise the `iOS.cmake`, but I don't have the capacity for this PR.