### PR TITLE
Android: Enable 16 KB ELF alignment for `arm64-v8a` and `x86_64` platforms

### DIFF
--- a/example/android/CMakeLists.txt
+++ b/example/android/CMakeLists.txt
@@ -41,6 +41,11 @@ if (CMAKE_CROSSCOMPILING)
   endif()
   target_compile_definitions(tdjni PRIVATE PACKAGE_NAME="org/drinkless/tdlib")
 
+  if (${ANDROID_ABI} STREQUAL "arm64-v8a" OR ${ANDROID_ABI} STREQUAL "x86_64")
+    # Enable 16 KB ELF alignment.
+    target_link_options(tdjni PRIVATE "-Wl,-z,max-page-size=16384")
+  endif()
+
   add_custom_command(TARGET tdjni POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E rename $<TARGET_FILE:tdjni> $<TARGET_FILE:tdjni>.debug
     COMMAND ${CMAKE_STRIP} --strip-debug --strip-unneeded $<TARGET_FILE:tdjni>.debug -o $<TARGET_FILE:tdjni>)


### PR DESCRIPTION
Starting November 1st, 2025, the ELF segments for shared libraries will have to be 16 KB aligned:
https://developer.android.com/guide/practices/page-sizes