### PR TITLE
Fix openssl build on Xcode 16.4+

### DIFF
--- a/example/ios/Python-Apple-support.patch
+++ b/example/ios/Python-Apple-support.patch
@@ -79,7 +79,7 @@ index a1d13e9..8efcf20 100644
  # The architecture of the machine doing the build
  HOST_ARCH=$(shell uname -m)
  HOST_PYTHON=install/macOS/macosx/python-$(PYTHON_VERSION)
-@@ -212,6 +236,10 @@ ARCH-$(target)=$$(subst .,,$$(suffix $(target)))
+@@ -212,12 +236,12 @@ ARCH-$(target)=$$(subst .,,$$(suffix $(target)))
  
  ifeq ($(os),macOS)
  TARGET_TRIPLE-$(target)=$$(ARCH-$(target))-apple-darwin
@@ -88,9 +88,15 @@ index a1d13e9..8efcf20 100644
 +else ifeq ($(os),visionOS-simulator)
 +TARGET_TRIPLE-$(target)=$$(ARCH-$(target))-apple-xros-simulator
  else
- 	ifeq ($$(findstring simulator,$$(SDK-$(target))),)
+-	ifeq ($$(findstring simulator,$$(SDK-$(target))),)
  TARGET_TRIPLE-$(target)=$$(ARCH-$(target))-apple-$$(OS_LOWER-$(target))
-@@ -662,7 +690,7 @@ BZIP2_FATLIB-$(sdk)=$$(BZIP2_MERGE-$(sdk))/lib/libbz2.a
+-	else
+-TARGET_TRIPLE-$(target)=$$(ARCH-$(target))-apple-$$(OS_LOWER-$(target))-simulator
+-	endif
+ endif
+ 
+ SDK_ROOT-$(target)=$$(shell xcrun --sdk $$(SDK-$(target)) --show-sdk-path)
+@@ -662,7 +686,7 @@ BZIP2_FATLIB-$(sdk)=$$(BZIP2_MERGE-$(sdk))/lib/libbz2.a
  XZ_MERGE-$(sdk)=$(PROJECT_DIR)/merge/$(os)/$(sdk)/xz-$(XZ_VERSION)
  XZ_FATLIB-$(sdk)=$$(XZ_MERGE-$(sdk))/lib/liblzma.a
  
@@ -99,7 +105,7 @@ index a1d13e9..8efcf20 100644
  OPENSSL_FATINCLUDE-$(sdk)=$$(OPENSSL_MERGE-$(sdk))/include
  OPENSSL_SSL_FATLIB-$(sdk)=$$(OPENSSL_MERGE-$(sdk))/lib/libssl.a
  OPENSSL_CRYPTO_FATLIB-$(sdk)=$$(OPENSSL_MERGE-$(sdk))/lib/libcrypto.a
-@@ -716,14 +744,14 @@ $$(OPENSSL_SSL_FATLIB-$(sdk)): $$(foreach target,$$(SDK_TARGETS-$(sdk)),$$(OPENS
+@@ -716,14 +740,14 @@ $$(OPENSSL_SSL_FATLIB-$(sdk)): $$(foreach target,$$(SDK_TARGETS-$(sdk)),$$(OPENS
  	mkdir -p $$(OPENSSL_MERGE-$(sdk))/lib
  	lipo -create -output $$@ \
  		$$(foreach target,$$(SDK_TARGETS-$(sdk)),$$(OPENSSL_SSL_LIB-$$(target))) \


### PR DESCRIPTION
This PR alters the patch for simulator targets of openssl and fixes the build on Xcode 16.4+

Turns out TDLib's patch had an issue with duplicated `-simulator` suffix that was ignored by clang of Xcode 16.0, but causes an issue with 16.4

`xcrun --sdk iphonesimulator clang -target x86_64-apple-ios-simulator-simulator -mios-simulator-version-min=12.0`

`clang: error: version '-simulator' in target triple 'arm64-apple-ios-simulator-simulator' is invalid`

When running `make vars-iOS-simulator`, I was able to spot an exact issue with `TARGET_TRIPLE`

```patch
@@ -4,10 +4,10 @@ iOS-simulator
 >>> Environment variables for iphonesimulator.x86_64
 SDK-iphonesimulator.x86_64: iphonesimulator
 ARCH-iphonesimulator.x86_64: x86_64
-TARGET_TRIPLE-iphonesimulator.x86_64: x86_64-apple-ios-simulator-simulator
+TARGET_TRIPLE-iphonesimulator.x86_64: x86_64-apple-ios-simulator
 SDK_ROOT-iphonesimulator.x86_64: /Applications/Xcode-16.0.0.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator18.0.sdk
-CC-iphonesimulator.x86_64: xcrun --sdk iphonesimulator clang -target x86_64-apple-ios-simulator-simulator
-CPP-iphonesimulator.x86_64: xcrun --sdk iphonesimulator clang -target x86_64-apple-ios-simulator-simulator -E
+CC-iphonesimulator.x86_64: xcrun --sdk iphonesimulator clang -target x86_64-apple-ios-simulator
+CPP-iphonesimulator.x86_64: xcrun --sdk iphonesimulator clang -target x86_64-apple-ios-simulator -E
 CFLAGS-iphonesimulator.x86_64: -mios-simulator-version-min=12.0
 LDFLAGS-iphonesimulator.x86_64: -mios-simulator-version-min=12.0
 BZIP2_SRCDIR-iphonesimulator.x86_64: build/iOS-simulator/iphonesimulator.x86_64/bzip2-1.0.8
@@ -37,10 +37,10 @@ PYTHON_LIB-iphonesimulator.x86_64: td/example/ios/Py
 >>> Environment variables for iphonesimulator.arm64
 SDK-iphonesimulator.arm64: iphonesimulator
 ARCH-iphonesimulator.arm64: arm64
-TARGET_TRIPLE-iphonesimulator.arm64: arm64-apple-ios-simulator-simulator
+TARGET_TRIPLE-iphonesimulator.arm64: arm64-apple-ios-simulator
 SDK_ROOT-iphonesimulator.arm64: /Applications/Xcode-16.0.0.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator18.0.sdk
-CC-iphonesimulator.arm64: xcrun --sdk iphonesimulator clang -target arm64-apple-ios-simulator-simulator
-CPP-iphonesimulator.arm64: xcrun --sdk iphonesimulator clang -target arm64-apple-ios-simulator-simulator -E
+CC-iphonesimulator.arm64: xcrun --sdk iphonesimulator clang -target arm64-apple-ios-simulator
+CPP-iphonesimulator.arm64: xcrun --sdk iphonesimulator clang -target arm64-apple-ios-simulator -E
 CFLAGS-iphonesimulator.arm64: -mios-simulator-version-min=12.0
 LDFLAGS-iphonesimulator.arm64: -mios-simulator-version-min=12.0
 BZIP2_SRCDIR-iphonesimulator.arm64: build/iOS-simulator/iphonesimulator.arm64/bzip2-1.0.8
```