### PR TITLE
Fix Java Example build.

### DIFF
--- a/example/java/org/drinkless/tdlib/example/Example.java
+++ b/example/java/org/drinkless/tdlib/example/Example.java
@@ -568,7 +568,7 @@ public final class Example {
                     TdApi.UpdateChatTheme updateChat = (TdApi.UpdateChatTheme) object;
                     TdApi.Chat chat = chats.get(updateChat.chatId);
                     synchronized (chat) {
-                        chat.themeName = updateChat.themeName;
+                        chat.theme = updateChat.theme;
                     }
                     break;
                 }


### PR DESCRIPTION
There was attempt of chat.themeName assignment. This class field was recently changed to chat.theme of ChatTheme object from chat.themeName.