### PR TITLE
Enhance pkg-config generation for interface libraries and Windows compatibility

### DIFF
--- a/CMake/GeneratePkgConfig.cmake
+++ b/CMake/GeneratePkgConfig.cmake
@@ -9,10 +9,20 @@ function(get_relative_link OUTPUT PATH)
   if (IS_ABSOLUTE ${PATH})
     get_filename_component(DIRECTORY_NAME "${PATH}" DIRECTORY)
     if (WIN32)
-      set(${OUTPUT} "-l\"${DIRECTORY_NAME}/${NAME}\"" PARENT_SCOPE)
+      # On Windows, library files can be libname.lib or name.lib
+      get_filename_component(FULL_NAME "${PATH}" NAME)
+      # Extract library name without lib prefix and extension
+      string(REGEX REPLACE "^lib(.+)\\.[^.]+$" "\\1" LIB_NAME "${FULL_NAME}")
+      # If the regex didn't match (no lib prefix), use the name without extension
+      if ("${LIB_NAME}" STREQUAL "${FULL_NAME}")
+        set(LIB_NAME "${NAME}")
+      endif()
+      set(${OUTPUT} "-L\"${DIRECTORY_NAME}\" -l${LIB_NAME}" PARENT_SCOPE)
     else()
       get_filename_component(FULL_NAME "${PATH}" NAME)
-      set(${OUTPUT} "-L\"${DIRECTORY_NAME}\" -l:${FULL_NAME}" PARENT_SCOPE)
+      # Extract library name without lib prefix and extension for all platforms
+      string(REGEX REPLACE "^lib(.+)\\.[^.]+$" "\\1" LIB_NAME "${FULL_NAME}")
+      set(${OUTPUT} "-L\"${DIRECTORY_NAME}\" -l${LIB_NAME}" PARENT_SCOPE)
     endif()
     return()
   endif()
@@ -31,17 +41,85 @@ function(generate_pkgconfig TARGET DESCRIPTION)
   # message("Generating pkg-config for ${TARGET}")
   get_filename_component(PREFIX "${CMAKE_INSTALL_PREFIX}" REALPATH)
 
-  get_target_property(LIST "${TARGET}" LINK_LIBRARIES)
+  # Get the target type to handle interface libraries differently
+  get_target_property(LIBRARY_TYPE "${TARGET}" TYPE)
+  # For interface libraries, use INTERFACE_LINK_LIBRARIES instead of LINK_LIBRARIES
+  if ("${LIBRARY_TYPE}" STREQUAL "INTERFACE_LIBRARY")
+    get_target_property(LIST "${TARGET}" INTERFACE_LINK_LIBRARIES)
+  else()
+    get_target_property(LIST "${TARGET}" LINK_LIBRARIES)
+  endif()
+
+  # Handle the case when no libraries are found
+  if ("${LIST}" STREQUAL "LIST-NOTFOUND")
+    set(LIST "")
+  endif()
+
+  # Special handling for tdcore interface library
+  if ("${TARGET}" STREQUAL "tdcore" AND "${LIBRARY_TYPE}" STREQUAL "INTERFACE_LIBRARY")
+    # For tdcore interface library, we need to link to the actual part libraries
+    # instead of the non-existent tdcore library
+    set(TDCORE_LIBS "")
+    set(COMBINED_REQS "")
+    set(COMBINED_LIBS "")
+    
+    foreach (PART_LIB ${LIST})
+      if (TARGET "${PART_LIB}" AND "${PART_LIB}" MATCHES "^tdcore_part[0-9]+$")
+        # Add the actual part library to link against
+        list(APPEND TDCORE_LIBS "-l${PART_LIB}")
+        
+        # Collect dependencies from the parts
+        get_target_property(PART_LIST "${PART_LIB}" LINK_LIBRARIES)
+        if (NOT "${PART_LIST}" STREQUAL "PART_LIST-NOTFOUND")
+          foreach (PART_DEP ${PART_LIST})
+            if (TARGET "${PART_DEP}")
+              list(APPEND COMBINED_REQS "${PART_DEP}")
+            else()
+              list(APPEND COMBINED_LIBS "${PART_DEP}")
+            endif()
+          endforeach()
+        endif()
+      elseif (TARGET "${PART_LIB}")
+        list(APPEND COMBINED_REQS "${PART_LIB}")
+      else()
+        list(APPEND COMBINED_LIBS "${PART_LIB}")
+      endif()
+    endforeach()
+
+    # Remove duplicates
+    if (COMBINED_REQS)
+      list(REMOVE_DUPLICATES COMBINED_REQS)
+    endif()
+    if (COMBINED_LIBS)
+      list(REMOVE_DUPLICATES COMBINED_LIBS)
+    endif()
+    if (TDCORE_LIBS)
+      list(REMOVE_DUPLICATES TDCORE_LIBS)
+    endif()
+
+    set(LIST "")
+    list(APPEND LIST ${COMBINED_REQS})
+    list(APPEND LIST ${COMBINED_LIBS})
+
+    # Set a flag to use different Libs line for tdcore
+    set(USE_TDCORE_PARTS TRUE)
+  else()
+    set(USE_TDCORE_PARTS FALSE)
+  endif()
+
   set(REQS "")
   set(LIBS "")
   foreach (LIB ${LIST})
     if (TARGET "${LIB}")
-      set(HAS_REQS 1)
-      list(APPEND REQS "${LIB}")
+      # Skip internal tdcore parts as they don't have their own .pc files
+      if (NOT "${LIB}" MATCHES "^tdcore_part[0-9]+$")
+        set(HAS_REQS 1)
+        list(APPEND REQS "${LIB}")
+      endif()
     else()
       set(HAS_LIBS 1)
       get_relative_link(LINK "${LIB}")
-      if (NOT LINK EQUAL "")
+      if (NOT "${LINK}" STREQUAL "")
         list(APPEND LIBS "${LINK}")
       endif()
     endif()
@@ -77,6 +155,19 @@ function(generate_pkgconfig TARGET DESCRIPTION)
   endif()
 
   file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/pkgconfig")
+  
+  # Generate the correct Libs line based on library type
+  if (USE_TDCORE_PARTS)
+    # For tdcore interface library, link to the actual part libraries
+    set(LIBS_LINE "")
+    foreach (PART_LIB ${TDCORE_LIBS})
+      set(LIBS_LINE "${LIBS_LINE} ${PART_LIB}")
+    endforeach()
+    set(LIBS_LINE "Libs: -L\"${PKGCONFIG_LIBDIR}\"${LIBS_LINE}")
+  else()
+    set(LIBS_LINE "Libs: -L\"${PKGCONFIG_LIBDIR}\" -l${TARGET}")
+  endif()
+  
   file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/${TARGET}.pc" CONTENT
 "prefix=${PREFIX}
 
@@ -85,14 +176,14 @@ Description: ${DESCRIPTION}
 Version: ${PROJECT_VERSION}
 
 CFlags: -I\"${PKGCONFIG_INCLUDEDIR}\"
-Libs: -L\"${PKGCONFIG_LIBDIR}\" -l${TARGET}
+${LIBS_LINE}
 ${REQUIRES}${LIBRARIES}")
 
-  get_target_property(LIBRARY_TYPE "${TARGET}" TYPE)
-  if (LIBRARY_TYPE STREQUAL "STATIC_LIBRARY" OR LIBRARY_TYPE STREQUAL "SHARED_LIBRARY")
+  if ("${LIBRARY_TYPE}" STREQUAL "STATIC_LIBRARY" OR "${LIBRARY_TYPE}" STREQUAL "SHARED_LIBRARY")
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/${TARGET}.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
-  elseif (LIBRARY_TYPE STREQUAL "INTERFACE_LIBRARY")
-    # TODO: support interface libraries
+  elseif ("${LIBRARY_TYPE}" STREQUAL "INTERFACE_LIBRARY")
+    # Interface libraries are also supported, install the .pc file
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/${TARGET}.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
   else()
     message(FATAL_ERROR "Don't know how to handle ${TARGET} of type ${LIBRARY_TYPE}")
   endif()

--- a/CMake/GeneratePkgConfig.cmake
+++ b/CMake/GeneratePkgConfig.cmake
@@ -72,6 +72,12 @@ function(generate_pkgconfig TARGET DESCRIPTION)
   set(LIBS "")
   foreach (LIB ${LIST})
     if (TARGET "${LIB}")
+      if ("${LIBRARY_TYPE}" STREQUAL "SHARED_LIBRARY")
+        get_target_property(LIB_TYPE "${LIB}" TYPE)
+        if ("${LIB_TYPE}" STREQUAL "STATIC_LIBRARY")
+          continue()
+        endif()
+      endif()
       set(HAS_REQS 1)
       list(APPEND REQS "${LIB}")
     else()
@@ -133,6 +139,16 @@ function(generate_pkgconfig TARGET DESCRIPTION)
     set(LIBS_LINE "Libs: -L\"${PKGCONFIG_LIBDIR}\" -l${TARGET_OUTPUT_NAME}")
   endif()
 
+  get_target_property(_td_iface_defs "${TARGET}" INTERFACE_COMPILE_DEFINITIONS)
+  set(CFLAGS_DEFS "")
+  if (NOT "${_td_iface_defs}" STREQUAL "_td_iface_defs-NOTFOUND")
+    foreach(_def ${_td_iface_defs})
+      string(APPEND CFLAGS_DEFS " -D${_def}")
+    endforeach()
+    unset(_def)
+  endif()
+  unset(_td_iface_defs)
+
   file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/${TARGET}.pc" CONTENT
 "prefix=${PREFIX}
 
@@ -140,7 +156,7 @@ Name: ${TARGET}
 Description: ${DESCRIPTION}
 Version: ${PROJECT_VERSION}
 
-CFlags: -I\"${PKGCONFIG_INCLUDEDIR}\"
+CFlags: -I\"${PKGCONFIG_INCLUDEDIR}\"${CFLAGS_DEFS}
 ${LIBS_LINE}
 ${REQUIRES}${LIBRARIES}")
 

--- a/CMake/GeneratePkgConfig.cmake
+++ b/CMake/GeneratePkgConfig.cmake
@@ -8,22 +8,13 @@ function(get_relative_link OUTPUT PATH)
   get_filename_component(NAME "${PATH}" NAME_WE)
   if (IS_ABSOLUTE ${PATH})
     get_filename_component(DIRECTORY_NAME "${PATH}" DIRECTORY)
-    if (WIN32)
-      # On Windows, library files can be libname.lib or name.lib
-      get_filename_component(FULL_NAME "${PATH}" NAME)
-      # Extract library name without lib prefix and extension
-      string(REGEX REPLACE "^lib(.+)\\.[^.]+$" "\\1" LIB_NAME "${FULL_NAME}")
-      # If the regex didn't match (no lib prefix), use the name without extension
-      if ("${LIB_NAME}" STREQUAL "${FULL_NAME}")
-        set(LIB_NAME "${NAME}")
-      endif()
-      set(${OUTPUT} "-L\"${DIRECTORY_NAME}\" -l${LIB_NAME}" PARENT_SCOPE)
-    else()
-      get_filename_component(FULL_NAME "${PATH}" NAME)
-      # Extract library name without lib prefix and extension for all platforms
-      string(REGEX REPLACE "^lib(.+)\\.[^.]+$" "\\1" LIB_NAME "${FULL_NAME}")
-      set(${OUTPUT} "-L\"${DIRECTORY_NAME}\" -l${LIB_NAME}" PARENT_SCOPE)
+    get_filename_component(FULL_NAME "${PATH}" NAME)
+    string(REGEX REPLACE "^lib(.+)\\.[^.]+$" "\\1" LIB_NAME "${FULL_NAME}")
+    # If the regex didn't match (no lib prefix), fall back to name without extension
+    if ("${LIB_NAME}" STREQUAL "${FULL_NAME}")
+      set(LIB_NAME "${NAME}")
     endif()
+    set(${OUTPUT} "-L\"${DIRECTORY_NAME}\" -l${LIB_NAME}" PARENT_SCOPE)
     return()
   endif()
 
@@ -41,81 +32,48 @@ function(generate_pkgconfig TARGET DESCRIPTION)
   # message("Generating pkg-config for ${TARGET}")
   get_filename_component(PREFIX "${CMAKE_INSTALL_PREFIX}" REALPATH)
 
-  # Get the target type to handle interface libraries differently
   get_target_property(LIBRARY_TYPE "${TARGET}" TYPE)
-  # For interface libraries, use INTERFACE_LINK_LIBRARIES instead of LINK_LIBRARIES
   if ("${LIBRARY_TYPE}" STREQUAL "INTERFACE_LIBRARY")
     get_target_property(LIST "${TARGET}" INTERFACE_LINK_LIBRARIES)
   else()
     get_target_property(LIST "${TARGET}" LINK_LIBRARIES)
   endif()
 
-  # Handle the case when no libraries are found
   if ("${LIST}" STREQUAL "LIST-NOTFOUND")
     set(LIST "")
   endif()
 
-  # Special handling for tdcore interface library
-  if ("${TARGET}" STREQUAL "tdcore" AND "${LIBRARY_TYPE}" STREQUAL "INTERFACE_LIBRARY")
-    # For tdcore interface library, we need to link to the actual part libraries
-    # instead of the non-existent tdcore library
-    set(TDCORE_LIBS "")
-    set(COMBINED_REQS "")
-    set(COMBINED_LIBS "")
-    
-    foreach (PART_LIB ${LIST})
-      if (TARGET "${PART_LIB}" AND "${PART_LIB}" MATCHES "^tdcore_part[0-9]+$")
-        # Add the actual part library to link against
-        list(APPEND TDCORE_LIBS "-l${PART_LIB}")
-        
-        # Collect dependencies from the parts
-        get_target_property(PART_LIST "${PART_LIB}" LINK_LIBRARIES)
-        if (NOT "${PART_LIST}" STREQUAL "PART_LIST-NOTFOUND")
-          foreach (PART_DEP ${PART_LIST})
-            if (TARGET "${PART_DEP}")
-              list(APPEND COMBINED_REQS "${PART_DEP}")
-            else()
-              list(APPEND COMBINED_LIBS "${PART_DEP}")
-            endif()
-          endforeach()
+  set(INTERFACE_LIBS "")
+  if ("${LIBRARY_TYPE}" STREQUAL "INTERFACE_LIBRARY")
+    set(PROPAGATED "")
+    foreach (DEP ${LIST})
+      if (TARGET "${DEP}")
+        get_target_property(DEP_TYPE "${DEP}" TYPE)
+        if ("${DEP_TYPE}" STREQUAL "STATIC_LIBRARY" OR "${DEP_TYPE}" STREQUAL "SHARED_LIBRARY")
+          list(APPEND INTERFACE_LIBS "${DEP}")
+          get_target_property(DEP_LIBS "${DEP}" LINK_LIBRARIES)
+          if (NOT "${DEP_LIBS}" STREQUAL "DEP_LIBS-NOTFOUND")
+            list(APPEND PROPAGATED ${DEP_LIBS})
+          endif()
+        else()
+          list(APPEND PROPAGATED "${DEP}")
         endif()
-      elseif (TARGET "${PART_LIB}")
-        list(APPEND COMBINED_REQS "${PART_LIB}")
       else()
-        list(APPEND COMBINED_LIBS "${PART_LIB}")
+        list(APPEND PROPAGATED "${DEP}")
       endif()
     endforeach()
-
-    # Remove duplicates
-    if (COMBINED_REQS)
-      list(REMOVE_DUPLICATES COMBINED_REQS)
+    if (PROPAGATED)
+      list(REMOVE_DUPLICATES PROPAGATED)
     endif()
-    if (COMBINED_LIBS)
-      list(REMOVE_DUPLICATES COMBINED_LIBS)
-    endif()
-    if (TDCORE_LIBS)
-      list(REMOVE_DUPLICATES TDCORE_LIBS)
-    endif()
-
-    set(LIST "")
-    list(APPEND LIST ${COMBINED_REQS})
-    list(APPEND LIST ${COMBINED_LIBS})
-
-    # Set a flag to use different Libs line for tdcore
-    set(USE_TDCORE_PARTS TRUE)
-  else()
-    set(USE_TDCORE_PARTS FALSE)
+    set(LIST "${PROPAGATED}")
   endif()
 
   set(REQS "")
   set(LIBS "")
   foreach (LIB ${LIST})
     if (TARGET "${LIB}")
-      # Skip internal tdcore parts as they don't have their own .pc files
-      if (NOT "${LIB}" MATCHES "^tdcore_part[0-9]+$")
-        set(HAS_REQS 1)
-        list(APPEND REQS "${LIB}")
-      endif()
+      set(HAS_REQS 1)
+      list(APPEND REQS "${LIB}")
     else()
       set(HAS_LIBS 1)
       get_relative_link(LINK "${LIB}")
@@ -155,19 +113,17 @@ function(generate_pkgconfig TARGET DESCRIPTION)
   endif()
 
   file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/pkgconfig")
-  
-  # Generate the correct Libs line based on library type
-  if (USE_TDCORE_PARTS)
-    # For tdcore interface library, link to the actual part libraries
+
+  if ("${LIBRARY_TYPE}" STREQUAL "INTERFACE_LIBRARY")
     set(LIBS_LINE "")
-    foreach (PART_LIB ${TDCORE_LIBS})
-      set(LIBS_LINE "${LIBS_LINE} ${PART_LIB}")
+    foreach (ILIB ${INTERFACE_LIBS})
+      set(LIBS_LINE "${LIBS_LINE} -l${ILIB}")
     endforeach()
     set(LIBS_LINE "Libs: -L\"${PKGCONFIG_LIBDIR}\"${LIBS_LINE}")
   else()
     set(LIBS_LINE "Libs: -L\"${PKGCONFIG_LIBDIR}\" -l${TARGET}")
   endif()
-  
+
   file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/${TARGET}.pc" CONTENT
 "prefix=${PREFIX}
 
@@ -179,10 +135,8 @@ CFlags: -I\"${PKGCONFIG_INCLUDEDIR}\"
 ${LIBS_LINE}
 ${REQUIRES}${LIBRARIES}")
 
-  if ("${LIBRARY_TYPE}" STREQUAL "STATIC_LIBRARY" OR "${LIBRARY_TYPE}" STREQUAL "SHARED_LIBRARY")
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/${TARGET}.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
-  elseif ("${LIBRARY_TYPE}" STREQUAL "INTERFACE_LIBRARY")
-    # Interface libraries are also supported, install the .pc file
+  if ("${LIBRARY_TYPE}" STREQUAL "STATIC_LIBRARY" OR "${LIBRARY_TYPE}" STREQUAL "SHARED_LIBRARY" OR
+      "${LIBRARY_TYPE}" STREQUAL "INTERFACE_LIBRARY")
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/${TARGET}.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
   else()
     message(FATAL_ERROR "Don't know how to handle ${TARGET} of type ${LIBRARY_TYPE}")

--- a/CMake/GeneratePkgConfig.cmake
+++ b/CMake/GeneratePkgConfig.cmake
@@ -114,14 +114,23 @@ function(generate_pkgconfig TARGET DESCRIPTION)
 
   file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/pkgconfig")
 
+  get_target_property(TARGET_OUTPUT_NAME "${TARGET}" OUTPUT_NAME)
+  if ("${TARGET_OUTPUT_NAME}" STREQUAL "TARGET_OUTPUT_NAME-NOTFOUND")
+    set(TARGET_OUTPUT_NAME "${TARGET}")
+  endif()
+
   if ("${LIBRARY_TYPE}" STREQUAL "INTERFACE_LIBRARY")
     set(LIBS_LINE "")
     foreach (ILIB ${INTERFACE_LIBS})
-      set(LIBS_LINE "${LIBS_LINE} -l${ILIB}")
+      get_target_property(ILIB_OUTPUT_NAME "${ILIB}" OUTPUT_NAME)
+      if ("${ILIB_OUTPUT_NAME}" STREQUAL "ILIB_OUTPUT_NAME-NOTFOUND")
+        set(ILIB_OUTPUT_NAME "${ILIB}")
+      endif()
+      set(LIBS_LINE "${LIBS_LINE} -l${ILIB_OUTPUT_NAME}")
     endforeach()
     set(LIBS_LINE "Libs: -L\"${PKGCONFIG_LIBDIR}\"${LIBS_LINE}")
   else()
-    set(LIBS_LINE "Libs: -L\"${PKGCONFIG_LIBDIR}\" -l${TARGET}")
+    set(LIBS_LINE "Libs: -L\"${PKGCONFIG_LIBDIR}\" -l${TARGET_OUTPUT_NAME}")
   endif()
 
   file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/${TARGET}.pc" CONTENT

--- a/CMake/GeneratePkgConfig.cmake
+++ b/CMake/GeneratePkgConfig.cmake
@@ -9,7 +9,7 @@ function(get_relative_link OUTPUT PATH)
   if (IS_ABSOLUTE ${PATH})
     get_filename_component(DIRECTORY_NAME "${PATH}" DIRECTORY)
     get_filename_component(FULL_NAME "${PATH}" NAME)
-    string(REGEX REPLACE "^lib(.+)\\.[^.]+$" "\\1" LIB_NAME "${FULL_NAME}")
+    string(REGEX REPLACE "^lib([^.]+).*$" "\\1" LIB_NAME "${FULL_NAME}")
     # If the regex didn't match (no lib prefix), fall back to name without extension
     if ("${LIB_NAME}" STREQUAL "${FULL_NAME}")
       set(LIB_NAME "${NAME}")


### PR DESCRIPTION
Back in 2024s problem of PE size exceeding was resolved https://github.com/tdlib/td/issues/2888, but actually the issue is still present and as workaround we need to split tdcore.lib into two part in case we build for Windows OS host, LTO enable flag comes here as helper to enforce splitting into two parts.

Unfortunately .pc generation handler for tdcore_part1.lib & tdcore_part2.lib was not implemented yet. This is attempt to make that splitting work. As https://github.com/microsoft/vcpkg/pull/47690 validates generated .pc would work against vcpkg ci. https://github.com/microsoft/vcpkg/pull/47690/files#diff-bab39c8782e3538fd5a1a88f8c113153002bff5f4410bc4329729a7e9a59e99dR1

```
FAILED: tdcore.lib 
C:\Windows\system32\cmd.exe /C "cd . && C:\PROGRA~1\MICROS~1\2022\ENTERP~1\VC\Tools\MSVC\1444~1.352\bin\Hostx64\x64\lib.exe  /machine:x64 /nologo /out:tdcore.lib @CMakeFiles\tdcore.rsp && cd ."
tdcore.lib : fatal error LNK1248: image size (1022142D3) exceeds maximum allowable size (FFFFFFFF)

ninja: build stopped: subcommand failed.
```