### PR TITLE
Specify that the sticker emoji can be empty

### DIFF
--- a/td/generate/scheme/td_api.tl
+++ b/td/generate/scheme/td_api.tl
@@ -476,7 +476,7 @@ photo has_stickers:Bool minithumbnail:minithumbnail sizes:vector<photoSize> = Ph
 //@set_id Identifier of the sticker set to which the sticker belongs; 0 if none
 //@width Sticker width; as defined by the sender
 //@height Sticker height; as defined by the sender
-//@emoji Emoji corresponding to the sticker
+//@emoji Emoji corresponding to the sticker; may be empty if unknown
 //@format Sticker format
 //@full_type Sticker's full type
 //@thumbnail Sticker thumbnail in WEBP or JPEG format; may be null


### PR DESCRIPTION
I noticed that if sending a sticker not from a sticker pack (my specific case is Emoji Kitchen from GBoard via Telegram for Android or Telegram X), the emoji is empty. My application didn't handle this correctly and showed such message in the chat list as empty. This is not specified in the documentation currently, but I think it should be.