### PR TITLE
Fix Java build.

### DIFF
--- a/example/java/org/drinkless/tdlib/example/Example.java
+++ b/example/java/org/drinkless/tdlib/example/Example.java
@@ -289,7 +289,7 @@ public final class Example {
 
     private static void sendMessage(long chatId, String message) {
         // initialize reply markup just for testing
-        TdApi.InlineKeyboardButton[] row = {new TdApi.InlineKeyboardButton("https://telegram.org?1", new TdApi.InlineKeyboardButtonTypeUrl()), new TdApi.InlineKeyboardButton("https://telegram.org?2", new TdApi.InlineKeyboardButtonTypeUrl()), new TdApi.InlineKeyboardButton("https://telegram.org?3", new TdApi.InlineKeyboardButtonTypeUrl())};
+        TdApi.InlineKeyboardButton[] row = {new TdApi.InlineKeyboardButton("https://telegram.org?1", 0, new TdApi.ButtonStyleDefault(), new TdApi.InlineKeyboardButtonTypeUrl()), new TdApi.InlineKeyboardButton("https://telegram.org?2", 0, new TdApi.ButtonStyleDefault(), new TdApi.InlineKeyboardButtonTypeUrl()), new TdApi.InlineKeyboardButton("https://telegram.org?3", 0, new TdApi.ButtonStyleDefault(), new TdApi.InlineKeyboardButtonTypeUrl())};
         TdApi.ReplyMarkup replyMarkup = new TdApi.ReplyMarkupInlineKeyboard(new TdApi.InlineKeyboardButton[][]{row, row, row});
 
         TdApi.InputMessageContent content = new TdApi.InputMessageText(new TdApi.FormattedText(message, null), null, true);


### PR DESCRIPTION
The new InlineKeyboardButton features (iconCustomEmojiId and style) were not used in the Example, and the constructors omitting these parameters were removed previously. Therefore, build for JNI was failing.