### PR TITLE
Fixes upstream bug #3604 in NetQueryDispatcher

### DIFF
--- a/td/telegram/net/NetQueryDispatcher.cpp
+++ b/td/telegram/net/NetQueryDispatcher.cpp
@@ -389,6 +389,16 @@ NetQueryDispatcher::~NetQueryDispatcher() = default;
 
 void NetQueryDispatcher::try_fix_migrate(NetQueryPtr &net_query) {
   auto error_message = net_query->error().message();
+  static constexpr CSlice file_migrate_prefix = "FILE_MIGRATE_";
+  if (begins_with(error_message, file_migrate_prefix)) {
+    auto new_dc_id = to_integer<int32>(error_message.substr(file_migrate_prefix.size()));
+    if (!DcId::is_valid(new_dc_id)) {
+      LOG(ERROR) << "Receive invalid DC ID in " << error_message;
+      return;
+    }
+    net_query->resend(DcId::internal(new_dc_id));
+    return;
+  }
   static constexpr CSlice prefixes[] = {"PHONE_MIGRATE_", "NETWORK_MIGRATE_", "USER_MIGRATE_"};
   for (auto &prefix : prefixes) {
     if (error_message.substr(0, prefix.size()) == prefix) {


### PR DESCRIPTION
Fixes #3604 and thus for downstream clients should fix custom contact photos. Fix applied at `NetQueryDispatcher.cpp:392-401`. Now, when a `FILE_MIGRATE_N` error (code 303) arrives:

1. `try_fix_migrate()` now matches the `FILE_MIGRATE_` prefix
2. Extracts the target DC ID, validates it
3. Resends the query to that DC — without changing the main DC (unlike `PHONE/NETWORK/USER_MIGRATE_`)
4. The query re-enters `dispatch()` in Query state and gets routed to the correct DC

Thanks for your time considering this pull request.