### PR TITLE
prevent ctypes GC crash (python tdlib example)

### DIFF
--- a/example/python/tdjson_example.py
+++ b/example/python/tdjson_example.py
@@ -89,7 +89,8 @@ class TdExample:
             if verbosity_level == 0:
                 sys.exit(f"TDLib fatal error: {message.decode('utf-8')}")
 
-        self._td_set_log_message_callback(2, on_log_message_callback)
+        self._log_message_callback = on_log_message_callback
+        self._td_set_log_message_callback(2, self._log_message_callback)
         self.execute(
             {"@type": "setLogVerbosityLevel", "new_verbosity_level": verbosity_level}
         )


### PR DESCRIPTION
Python does not know about arbitrary C pointers. Therefore, the programmer must keep the Python/ctypes object alive as long as the C code may use its address. I fixed the code so that it contains direct references to the object, to avoid issues with the garbage collector (GC).

> Make sure you keep references to CFUNCTYPE() objects as long as they are used from C code. ctypes doesn't, and if you don't, they may be garbage collected, crashing your program when a callback is made.

Reference: https://docs.python.org/3/library/ctypes.html#callback-functions

