### PR TITLE
Fix missing `get_git_commit_hash` when building with iOS toolchain. Fixes #3663

### DIFF
--- a/CMake/GetGitRevisionDescription.cmake
+++ b/CMake/GetGitRevisionDescription.cmake
@@ -71,7 +71,11 @@ function(get_git_head_revision _refspecvar _hashvar)
     return()
   endif()
 
-  find_package(Git QUIET)
+  if (COMMAND find_host_package)
+    find_host_package(Git QUIET)
+  else()
+    find_package(Git QUIET)
+  endif()
 
   # Check if the current source dir is a git submodule or a worktree.
   # In both cases .git is a file instead of a directory.

--- a/CMake/iOS.cmake
+++ b/CMake/iOS.cmake
@@ -252,13 +252,6 @@ set (CMAKE_SYSTEM_FRAMEWORK_PATH
     ${CMAKE_IOS_SDK_ROOT}/Developer/Library/Frameworks
 )
 
-# CMAKE_FIND_ROOT_PATH_MODE_PROGRAM below is overly restrictive for host tools.
-# Find Git before restricting search paths, so GetGitRevisionDescription.cmake works with this iOS toolchain.
-if (NOT Git_FOUND)
-    set (CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
-    find_package(Git QUIET)
-endif()
-
 # only search the iOS sdks, not the remainder of the host filesystem
 set (CMAKE_FIND_ROOT_PATH_MODE_PROGRAM ONLY)
 set (CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)

--- a/CMake/iOS.cmake
+++ b/CMake/iOS.cmake
@@ -252,6 +252,13 @@ set (CMAKE_SYSTEM_FRAMEWORK_PATH
     ${CMAKE_IOS_SDK_ROOT}/Developer/Library/Frameworks
 )
 
+# CMAKE_FIND_ROOT_PATH_MODE_PROGRAM below is overly restrictive for host tools.
+# Find Git before restricting search paths, so GetGitRevisionDescription.cmake works with this iOS toolchain.
+if (NOT Git_FOUND)
+    set (CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+    find_package(Git QUIET)
+endif()
+
 # only search the iOS sdks, not the remainder of the host filesystem
 set (CMAKE_FIND_ROOT_PATH_MODE_PROGRAM ONLY)
 set (CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)


### PR DESCRIPTION
Since it's purely `iOS.cmake`'s issue ~, I've added a local only workaround.~

Without the fix, cmake will try to search for git in `/Applications/Xcode-26.2.0.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs` and will eventually fail.

P.S. I think it's the third time (#3303) we're having troubles finding host tools when building for iOS. This cmake file is a candidate for an overhaul!