### PR TITLE
Remove CMAKE_FIND_ROOT_PATH_MODE_PROGRAM ONLY in iOS.cmake builds

### DIFF
--- a/CMake/iOS.cmake
+++ b/CMake/iOS.cmake
@@ -253,7 +253,6 @@ set (CMAKE_SYSTEM_FRAMEWORK_PATH
 )
 
 # only search the iOS sdks, not the remainder of the host filesystem
-set (CMAKE_FIND_ROOT_PATH_MODE_PROGRAM ONLY)
 set (CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set (CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 
@@ -264,7 +263,6 @@ endmacro (set_xcode_property)
 
 # This macro lets you find executable programs on the host system
 macro (find_host_package)
-    set (CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
     set (CMAKE_FIND_ROOT_PATH_MODE_LIBRARY NEVER)
     set (CMAKE_FIND_ROOT_PATH_MODE_INCLUDE NEVER)
     set (IOS FALSE)
@@ -272,7 +270,6 @@ macro (find_host_package)
     find_package(${ARGN})
 
     set (IOS TRUE)
-    set (CMAKE_FIND_ROOT_PATH_MODE_PROGRAM ONLY)
     set (CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
     set (CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 endmacro (find_host_package)

--- a/example/ios/build.sh
+++ b/example/ios/build.sh
@@ -55,7 +55,7 @@ do
       fi
 
       echo "iOS platform = ${ios_platform}"
-      other_options="-DIOS_PLATFORM=${ios_platform} -DCMAKE_TOOLCHAIN_FILE=${td_path}/CMake/iOS.cmake -DCMAKE_MAKE_PROGRAM=make"
+      other_options="-DIOS_PLATFORM=${ios_platform} -DCMAKE_TOOLCHAIN_FILE=${td_path}/CMake/iOS.cmake"
     fi
 
     set_cmake_options $platform


### PR DESCRIPTION
This PR removes a restrictive `set (CMAKE_FIND_ROOT_PATH_MODE_PROGRAM ONLY)` that prevented Cmake to properly find host programs like `git`, `make`, `ccache` when building with `iOS.cmake` toolchain.


I've made a [full build](https://github.com/Swiftgram/TDLibFramework/actions/runs/27440977685) in my fork, here're notable highlights:
- Correctly finds `ccache`. [Previously](https://t.me/tdlibchat/108339) it was never found even on systems with installed ccache.
- Correctly finds `git` and calculates SHA commit for TDLib submodule.
```
Git state: 11be438651fab745fa3a6a70fcab6477eb3a4ae8
```
- Correctly finds `make`, no need to set `CMAKE_MAKE_PROGRAM` option for Cmake 4.3.3.
- Correctly finds `OpenSSL` when directly provided. No unexpected host overrides happens here.
```
Found OpenSSL: /Users/runner/work/TDLibFramework/TDLibFramework/td/example/ios/third_party/openssl/macOS/include
```
- Correctly finds `ZLIB`.
```
Found ZLIB: /Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib/libz.tbd (found version "1.2.12")
```
- No differences when configuring builds for [macOS](https://github.com/Swiftgram/TDLibFramework/actions/runs/27440977685/job/81114772578) or [other](https://github.com/Swiftgram/TDLibFramework/actions/runs/27440977685/job/81114799089) Apple targets.

This PR reverts #3303 
This PR fixes #3663