### PR TITLE
build: pin tl-parser to C11 for GCC 15 / Clang 16 compatibility

### DIFF
--- a/td/generate/tl-parser/wgetopt.c
+++ b/td/generate/tl-parser/wgetopt.c
@@ -213,7 +213,7 @@ in GCC.  */
 whose names are inconsistent.  */
 
 #ifndef getenv
-extern char *getenv();
+extern char *getenv(const char *);
 #endif
 
 static char *

--- a/td/generate/tl-parser/wgetopt.h
+++ b/td/generate/tl-parser/wgetopt.h
@@ -168,7 +168,7 @@ extern int __posix_getopt (int ___argc, char *const *___argv,
 #  endif
 # endif
 #else /* not __GNU_LIBRARY__ */
-extern int getopt ();
+extern int getopt (int, char *const *, const char *);
 #endif /* __GNU_LIBRARY__ */
 
 #ifndef __need_getopt


### PR DESCRIPTION
The vendored wgetopt.c (Windows-only) uses K&R-style definitions and the legacy declaration `extern char *getenv();`. GCC 15 and Clang 16 default to -std=gnu23, where () means "no arguments", so the call `getenv("POSIXLY_CORRECT")` is rejected as too many arguments.

Pin the tl-parser target to C11 on GCC/Clang. MSVC unaffected (the existing /utf-8 /wd4101 /wd4244 /wd4267 block already handles it). Host-side codegen helper -- no runtime impact.

## Test plan
- Built successfully on MSYS2 MinGW64 with GCC 15.2 (previously failed
  at `wgetopt.c` without this patch).
- MSVC build path unchanged (this patch is gated on `CMAKE_C_COMPILER_ID
  MATCHES "GNU|Clang"`).