### PR TITLE
Fix typos issues across the codebase

### DIFF
--- a/td/generate/scheme/td_api.tl
+++ b/td/generate/scheme/td_api.tl
@@ -12448,10 +12448,10 @@ addQuickReplyShortcutInlineQueryResultMessage shortcut_name:string reply_to_mess
 //@input_message_contents Contents of messages to be sent. At most 10 messages can be added to an album. All messages must have the same value of show_caption_above_media
 addQuickReplyShortcutMessageAlbum shortcut_name:string reply_to_message_id:int53 input_message_contents:vector<InputMessageContent> = QuickReplyMessages;
 
-//@description Readds quick reply messages which failed to add. Can be called only for messages for which messageSendingStateFailed.can_retry is true and after specified in messageSendingStateFailed.retry_after time passed.
-//-If a message is readded, the corresponding failed to send message is deleted. Returns the sent messages in the same order as the message identifiers passed in message_ids. If a message can't be readded, null will be returned instead of the message
+//@description Re-adds quick reply messages which failed to add. Can be called only for messages for which messageSendingStateFailed.can_retry is true and after specified in messageSendingStateFailed.retry_after time passed.
+//-If a message is re-added, the corresponding failed to send message is deleted. Returns the sent messages in the same order as the message identifiers passed in message_ids. If a message can't be readded, null will be returned instead of the message
 //@shortcut_name Name of the target shortcut
-//@message_ids Identifiers of the quick reply messages to readd. Message identifiers must be in a strictly increasing order
+//@message_ids Identifiers of the quick reply messages to re-add. Message identifiers must be in a strictly increasing order
 readdQuickReplyShortcutMessages shortcut_name:string message_ids:vector<int53> = QuickReplyMessages;
 
 //@description Asynchronously edits the text, media or caption of a quick reply message. Use quickReplyMessage.can_be_edited to check whether a message can be edited.

--- a/td/telegram/BotInfoManager.cpp
+++ b/td/telegram/BotInfoManager.cpp
@@ -1079,7 +1079,7 @@ void BotInfoManager::on_upload_bot_media_preview(FileUploadId file_upload_id,
     }
     pending_preview->was_reuploaded_ = true;
 
-    // delete file reference and forcely reupload the file
+    // delete file reference and forcibly reupload the file
     td_->file_manager_->delete_file_reference(file_upload_id.get_file_id(), main_remote_location->get_file_reference());
     return do_add_bot_media_preview(std::move(pending_preview), {-1});
   }

--- a/td/telegram/ChatManager.cpp
+++ b/td/telegram/ChatManager.cpp
@@ -7022,14 +7022,14 @@ void ChatManager::on_update_chat_add_user(ChatId chat_id, UserId inviter_user_id
     for (auto &participant : chat_full->participants) {
       if (participant.dialog_id_ == DialogId(user_id)) {
         if (participant.inviter_user_id_ != inviter_user_id) {
-          LOG(ERROR) << user_id << " was readded to " << chat_id << " by " << inviter_user_id
+          LOG(ERROR) << user_id << " was re-added to " << chat_id << " by " << inviter_user_id
                      << ", previously invited by " << participant.inviter_user_id_;
           participant.inviter_user_id_ = inviter_user_id;
           participant.joined_date_ = date;
           repair_chat_participants(chat_id);
         } else {
           // Possible if update comes twice
-          LOG(INFO) << user_id << " was readded to " << chat_id;
+          LOG(INFO) << user_id << " was re-added to " << chat_id;
         }
         return;
       }

--- a/td/telegram/DialogManager.cpp
+++ b/td/telegram/DialogManager.cpp
@@ -2539,7 +2539,7 @@ void DialogManager::on_upload_dialog_photo(FileUploadId file_upload_id,
 
     if (is_animation) {
       CHECK(file_view.get_type() == FileType::Animation);
-      // delete file reference and forcely reupload the file
+      // delete file reference and forcibly reupload the file
       auto file_reference = FileManager::extract_file_reference(main_remote_location->as_input_document());
       td_->file_manager_->delete_file_reference(file_upload_id.get_file_id(), file_reference);
       upload_dialog_photo(dialog_id, file_upload_id, is_animation, main_frame_timestamp, true, std::move(promise),

--- a/td/telegram/DialogParticipant.h
+++ b/td/telegram/DialogParticipant.h
@@ -402,11 +402,11 @@ class DialogParticipantStatus {
   // legacy rights
   static DialogParticipantStatus ChannelAdministrator(bool is_current_user_creator, bool is_megagroup);
 
-  // forcely returns an administrator
+  // forcibly returns an administrator
   DialogParticipantStatus(bool can_be_edited, tl_object_ptr<telegram_api::chatAdminRights> &&admin_rights, string rank,
                           ChannelType channel_type);
 
-  // forcely returns a restricted or banned
+  // forcibly returns a restricted or banned
   DialogParticipantStatus(bool is_member, tl_object_ptr<telegram_api::chatBannedRights> &&banned_rights,
                           ChannelType channel_type, string rank);
 

--- a/td/telegram/MessageContent.cpp
+++ b/td/telegram/MessageContent.cpp
@@ -13281,7 +13281,7 @@ void add_message_content_dependencies(Dependencies &dependencies, const MessageC
       break;
     case MessageContentType::Poll: {
       const auto *content = static_cast<const MessagePoll *>(message_content);
-      // no need to add poll dependencies, because they are forcely loaded with the poll
+      // no need to add poll dependencies, because they are forcibly loaded with the poll
       if (content->attached_media != nullptr) {
         add_message_content_dependencies(dependencies, content->attached_media.get(), my_user_id, is_bot);
       }

--- a/td/telegram/MessageImportManager.cpp
+++ b/td/telegram/MessageImportManager.cpp
@@ -389,7 +389,7 @@ void MessageImportManager::on_upload_imported_messages(FileUploadId file_upload_
     }
 
     CHECK(file_view.get_type() == FileType::Document);
-    // delete file reference and forcely reupload the file
+    // delete file reference and forcibly reupload the file
     auto file_reference = FileManager::extract_file_reference(main_remote_location->as_input_document());
     td_->file_manager_->delete_file_reference(file_upload_id.get_file_id(), file_reference);
     upload_imported_messages(dialog_id, file_upload_id, std::move(attached_file_upload_ids), true, std::move(promise),
@@ -522,7 +522,7 @@ void MessageImportManager::on_upload_imported_message_attachment(
       return promise.set_error(400, "Failed to reupload the file");
     }
 
-    // delete file reference and forcely reupload the file
+    // delete file reference and forcibly reupload the file
     auto file_reference = file_view.get_type() == FileType::Photo
                               ? FileManager::extract_file_reference(main_remote_location->as_input_photo())
                               : FileManager::extract_file_reference(main_remote_location->as_input_document());

--- a/td/telegram/MessagesManager.cpp
+++ b/td/telegram/MessagesManager.cpp
@@ -8173,7 +8173,7 @@ bool MessagesManager::can_approve_message(DialogId dialog_id, const Message *m) 
   if (is_from_user) {
     auto channel_id = td_->chat_manager_->get_monoforum_channel_id(dialog_id.get_channel_id());
     if (!td_->chat_manager_->get_channel_status(channel_id).can_post_messages()) {
-      // there are no enough rights
+      // there are not enough rights
       return false;
     }
   } else {
@@ -20813,7 +20813,7 @@ unique_ptr<MessagesManager::Message> MessagesManager::create_message_to_send(
   auto top_thread_message_id = is_general ? MessageId() : initial_top_thread_message_id;
   auto same_chat_reply_to_message_id = input_reply_to.get_same_chat_reply_to_message_id();
   if (same_chat_reply_to_message_id.is_valid() || same_chat_reply_to_message_id.is_valid_scheduled()) {
-    // the message was forcely preloaded in create_message_input_reply_to
+    // the message was forcibly preloaded in create_message_input_reply_to
     // it can be missing, only if it is unknown message from a push notification, or an unknown top thread message
     const Message *reply_m = get_message(d, same_chat_reply_to_message_id);
     if (reply_m != nullptr && !same_chat_reply_to_message_id.is_scheduled()) {
@@ -26612,7 +26612,7 @@ bool MessagesManager::add_new_message_notification(Dialog *d, Message *m, bool f
     return false;
   }
 
-  VLOG(notifications) << "Trying to " << (force ? "forcely " : "") << "add new message notification for "
+  VLOG(notifications) << "Trying to " << (force ? "forcibly " : "") << "add new message notification for "
                       << m->message_id << " in " << d->dialog_id
                       << (m->disable_notification ? " silently" : " with sound");
 
@@ -29118,7 +29118,7 @@ void MessagesManager::on_update_dialog_group_call(DialogId dialog_id, bool has_a
   }
   if (!force && d->active_group_call_id.is_valid() && has_active_group_call &&
       td_->group_call_manager_->is_group_call_being_joined(d->active_group_call_id)) {
-    LOG(INFO) << "Ignore update in a being joined group call";
+    LOG(INFO) << "Ignore update in a group call being joined";
     return;
   }
 
@@ -29173,7 +29173,7 @@ void MessagesManager::on_update_dialog_default_join_group_call_as_dialog_id(Dial
 
   if (!force && d->active_group_call_id.is_valid() &&
       td_->group_call_manager_->is_group_call_being_joined(d->active_group_call_id)) {
-    LOG(INFO) << "Ignore default_join_as_dialog_id update in a being joined group call";
+    LOG(INFO) << "Ignore default_join_as_dialog_id update in a group call being joined";
     return;
   }
 
@@ -32084,7 +32084,7 @@ bool MessagesManager::update_message(Dialog *d, Message *old_message, unique_ptr
         CHECK(d->scheduled_messages != nullptr);
         CHECK(is_message_in_dialog);
         // scheduled_message_date_ must be in sync with scheduled_messages_, therefore it must not be changed there.
-        // The message will be deleted and readded soon because its message_id has changed
+        // The message will be deleted and re-added soon because its message_id has changed
         // int32 &date = d->scheduled_messages->scheduled_message_date_[message_id.get_scheduled_server_message_id()];
         // CHECK(date != 0);
         // date = new_message->date;

--- a/td/telegram/StoryManager.cpp
+++ b/td/telegram/StoryManager.cpp
@@ -6132,7 +6132,7 @@ void StoryManager::on_upload_story(FileUploadId file_upload_id,
     }
     pending_story->was_reuploaded_ = true;
 
-    // delete file reference and forcely reupload the file
+    // delete file reference and forcibly reupload the file
     td_->file_manager_->delete_file_reference(file_upload_id.get_file_id(), main_remote_location->get_file_reference());
     do_send_story(std::move(pending_story), {-1});
     return;

--- a/td/telegram/UserManager.cpp
+++ b/td/telegram/UserManager.cpp
@@ -6134,7 +6134,7 @@ void UserManager::on_upload_profile_photo(FileUploadId file_upload_id,
       return promise.set_error(400, "Failed to reupload the file");
     }
 
-    // delete file reference and forcely reupload the file
+    // delete file reference and forcibly reupload the file
     if (is_animation) {
       CHECK(file_view.get_type() == FileType::Animation);
       LOG_CHECK(main_remote_location->is_common()) << *main_remote_location;

--- a/tde2e/td/e2e/CheckSharedSecret.cpp
+++ b/tde2e/td/e2e/CheckSharedSecret.cpp
@@ -30,7 +30,7 @@ td::Result<td::UInt256> CheckSharedSecret::reveal_nonce() const {
   return nonce_;
 }
 
-td::Status CheckSharedSecret::recive_commit_nonce(const td::UInt256 &other_nonce_hash) {
+td::Status CheckSharedSecret::receive_commit_nonce(const td::UInt256 &other_nonce_hash) {
   if (o_other_nonce_hash_) {
     return td::Status::Error("Already received other nonce hash");
   }

--- a/tde2e/td/e2e/CheckSharedSecret.h
+++ b/tde2e/td/e2e/CheckSharedSecret.h
@@ -24,7 +24,7 @@ struct CheckSharedSecret {
   static CheckSharedSecret create();
   td::UInt256 commit_nonce() const;
   td::Result<td::UInt256> reveal_nonce() const;
-  td::Status recive_commit_nonce(const td::UInt256 &other_nonce_hash);
+  td::Status receive_commit_nonce(const td::UInt256 &other_nonce_hash);
   td::Status receive_reveal_nonce(const td::UInt256 &other_nonce);
   td::Result<td::UInt256> finalize_hash(td::Slice shared_secret) const;
 };

--- a/tde2e/test/e2e.cpp
+++ b/tde2e/test/e2e.cpp
@@ -169,8 +169,8 @@ TEST(CheckSharedSecret, Basic) {
   auto alice = CheckSharedSecret::create();
   auto bob = CheckSharedSecret::create();
 
-  alice.recive_commit_nonce(bob.commit_nonce()).ensure();
-  bob.recive_commit_nonce(alice.commit_nonce()).ensure();
+  alice.receive_commit_nonce(bob.commit_nonce()).ensure();
+  bob.receive_commit_nonce(alice.commit_nonce()).ensure();
 
   alice.receive_reveal_nonce(bob.reveal_nonce().move_as_ok()).ensure();
   bob.receive_reveal_nonce(alice.reveal_nonce().move_as_ok()).ensure();

--- a/tdutils/generate/generate_mime_types_gperf.cpp
+++ b/tdutils/generate/generate_mime_types_gperf.cpp
@@ -121,12 +121,12 @@ int main(int argc, char *argv[]) {
     }
     assert(!extensions.empty());
 
-    std::map<std::string, std::string> preffered_extensions{{"image/jpeg", "jpg"},  {"audio/mpeg", "mp3"},
+    std::map<std::string, std::string> preferred_extensions{{"image/jpeg", "jpg"},  {"audio/mpeg", "mp3"},
                                                             {"audio/midi", "midi"}, {"text/x-pascal", "pas"},
                                                             {"text/x-asm", "asm"},  {"video/quicktime", "mov"}};
     std::size_t index = 0;
-    if (preffered_extensions.count(mime_type) != 0) {
-      index = std::find(extensions.begin(), extensions.end(), preffered_extensions[mime_type]) - extensions.begin();
+    if (preferred_extensions.count(mime_type) != 0) {
+      index = std::find(extensions.begin(), extensions.end(), preferred_extensions[mime_type]) - extensions.begin();
       assert(index < extensions.size());
     }
     if (mime_type_to_extension.emplace_hint(mime_type_to_extension.end(), mime_type, extensions[index])->second !=


### PR DESCRIPTION
This pull request focuses on correcting typos and improving the clarity of comments, log messages, and error messages throughout the codebase. The main changes involve replacing incorrect words such as "forcely" with "forcibly", fixing various spelling mistakes, and updating some log and error messages for better readability and accuracy.

**Typo and Wording Corrections:**

* Replaced all occurrences of "forcely" with "forcibly" in comments and log messages across multiple files, including `BotInfoManager.cpp`, `ChatManager.cpp`, `DialogManager.cpp`, `DialogParticipant.h`, `MessageContent.cpp`, `MessageImportManager.cpp`, `MessagesManager.cpp`, `StoryManager.cpp`, and `UserManager.cpp`. [[1]](diffhunk://#diff-92a7a632d6c4afd3add77ab11b7708137bbb8837b542e534f8b1b355328fc49eL1082-R1082) [[2]](diffhunk://#diff-cd5e14bcc87643e65ac65810a8ddee37589795c99896161fcc787d144c3b72fdL5106-R5106) [[3]](diffhunk://#diff-1c69a0e7498d6b692e6a75c9831b6846332388ba88b516d59f2eb886448d08e6L2538-R2538) [[4]](diffhunk://#diff-fc5969dd5858c68b62541f20e8d596757aea4936887d4f644ee8c368f013b116L387-R391) [[5]](diffhunk://#diff-f28fcc75c22b2ad7d34786442cb6c8d03ffb7fedb7a549d8b0abdef32f7458d4L13060-R13060) [[6]](diffhunk://#diff-88a78f2adb9f33341a0a0881cf83284e62a5f1b0e0ed86b1ad0afc298f4244ceL389-R389) [[7]](diffhunk://#diff-88a78f2adb9f33341a0a0881cf83284e62a5f1b0e0ed86b1ad0afc298f4244ceL524-R524) [[8]](diffhunk://#diff-4e078516f51faffeb3fdfcaa096104b8590f1bd354667b86ccb889a1df60917fL20576-R20576) [[9]](diffhunk://#diff-4e078516f51faffeb3fdfcaa096104b8590f1bd354667b86ccb889a1df60917fL26268-R26268) [[10]](diffhunk://#diff-44d742c172ef5ef91b22a2502f470dececd8f0acdd5832b68ac6d475e5275a87L6135-R6135) [[11]](diffhunk://#diff-55163b7d8c09e7c5e24bc3f6451098b42f009c3fab8f86a36a8e019bf79a98bcL6093-R6093)
* Fixed spelling errors and improved grammar in comments and error messages, such as changing "mistmatch" to "mismatch", "preceed" to "precede", and "enougth" to "enough" in `tl-parser.c` and `tl-parser.h`. [[1]](diffhunk://#diff-09179685e6fbc87efae208e6bb7de3c488294d6c0b6fe7acc8d13fb0f0711f9eL1540-R1548) [[2]](diffhunk://#diff-09179685e6fbc87efae208e6bb7de3c488294d6c0b6fe7acc8d13fb0f0711f9eL1557-R1557) [[3]](diffhunk://#diff-09179685e6fbc87efae208e6bb7de3c488294d6c0b6fe7acc8d13fb0f0711f9eL1569-R1569) [[4]](diffhunk://#diff-09179685e6fbc87efae208e6bb7de3c488294d6c0b6fe7acc8d13fb0f0711f9eL1582-R1582) [[5]](diffhunk://#diff-09179685e6fbc87efae208e6bb7de3c488294d6c0b6fe7acc8d13fb0f0711f9eL1656-R1656) [[6]](diffhunk://#diff-09179685e6fbc87efae208e6bb7de3c488294d6c0b6fe7acc8d13fb0f0711f9eL1684-R1684) [[7]](diffhunk://#diff-09179685e6fbc87efae208e6bb7de3c488294d6c0b6fe7acc8d13fb0f0711f9eL2030-R2030) [[8]](diffhunk://#diff-09179685e6fbc87efae208e6bb7de3c488294d6c0b6fe7acc8d13fb0f0711f9eL2147-R2147) [[9]](diffhunk://#diff-09179685e6fbc87efae208e6bb7de3c488294d6c0b6fe7acc8d13fb0f0711f9eL2156-R2156) [[10]](diffhunk://#diff-09179685e6fbc87efae208e6bb7de3c488294d6c0b6fe7acc8d13fb0f0711f9eL2401-R2401) [[11]](diffhunk://#diff-09179685e6fbc87efae208e6bb7de3c488294d6c0b6fe7acc8d13fb0f0711f9eL2536-R2536) [[12]](diffhunk://#diff-55240fb0f47b96a3678afaa4ee6fd7ad97d9d849cc6ea68d8293291665825f4cL2-R2)
* Updated log messages to use consistent terminology, such as replacing "was readded" with "was re-added" and improving the description of group call updates in `MessagesManager.cpp`. [[1]](diffhunk://#diff-cd5e14bcc87643e65ac65810a8ddee37589795c99896161fcc787d144c3b72fdL6955-R6962) [[2]](diffhunk://#diff-4e078516f51faffeb3fdfcaa096104b8590f1bd354667b86ccb889a1df60917fL28762-R28762) [[3]](diffhunk://#diff-4e078516f51faffeb3fdfcaa096104b8590f1bd354667b86ccb889a1df60917fL28817-R28817) [[4]](diffhunk://#diff-4e078516f51faffeb3fdfcaa096104b8590f1bd354667b86ccb889a1df60917fL31712-R31712)
* Improved English in API documentation comments, such as changing "readds" to "re-adds" and "readd" to "re-add" in `td_api.tl`.

These changes do not affect the functionality of the code but enhance code quality, maintainability, and developer experience by making messages and documentation more clear and professional.