### PR TITLE
Fix Markdown formatting offsets for non-ASCII URLs

### DIFF
--- a/td/telegram/MessageEntity.cpp
+++ b/td/telegram/MessageEntity.cpp
@@ -3136,7 +3136,7 @@ FormattedText get_markdown_v3(FormattedText text) {
             result.text += "](";
             result.text += entity->argument;
             result.text += ')';
-            utf16_added += narrow_cast<int32>(3 + entity->argument.size());
+            utf16_added += 3 + text_length(entity->argument);
             break;
           case MessageEntity::Type::Code:
             result.text += '`';

--- a/test/message_entities.cpp
+++ b/test/message_entities.cpp
@@ -2026,6 +2026,9 @@ TEST(MessageEntities, get_markdown_v3) {
   check_get_markdown_v3(
       "[ ]t.me[)](http://t.me/) [ ](t.me)", {{25, 1, td::UserId(static_cast<td::int64>(1))}}, "[ ]t.me) [ ](t.me)",
       {{td::MessageEntity::Type::TextUrl, 7, 1, "http://t.me/"}, {9, 1, td::UserId(static_cast<td::int64>(1))}});
+  check_get_markdown_v3("[a](http://t.me/аб)b", {{19, 1, td::CustomEmojiId(static_cast<td::int64>(1))}}, "ab",
+                        {{td::MessageEntity::Type::TextUrl, 0, 1, "http://t.me/аб"},
+                         {td::MessageEntity::Type::CustomEmoji, 1, 1, td::CustomEmojiId(static_cast<td::int64>(1))}});
 
   check_get_markdown_v3("__ __", {}, " ", {{td::MessageEntity::Type::Italic, 0, 1}});
   check_get_markdown_v3("** **", {}, " ", {{td::MessageEntity::Type::Bold, 0, 1}});


### PR DESCRIPTION
## Summary
- count TextUrl URL arguments in UTF-16 code units when adjusting generated Markdown entity offsets
- add a regression for a non-ASCII URL followed by a preserved custom emoji entity

Fixes #3686.

## Tests
- git diff --check upstream/master...HEAD
- Not run: CMake test target, because cmake is not installed in this environment.